### PR TITLE
Error handling for a node calls.

### DIFF
--- a/src/controllers/ControllerBase.ts
+++ b/src/controllers/ControllerBase.ts
@@ -1,0 +1,10 @@
+import { injectable } from 'inversify';
+import { Response } from 'express';
+
+@injectable()
+export class ControllerBase {
+    protected handleError(res: Response, err: Error) {
+        const ERROR_STATUS = 500;
+        res.status(ERROR_STATUS).send(err.message);
+    }
+}

--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -3,14 +3,17 @@ import { injectable, inject } from 'inversify';
 import { NetworkType } from '../networks';
 import { IDappsStakingService } from '../services/DappsStakingService';
 import { IStatsIndexerService, PeriodType } from '../services/StatsIndexerService';
+import { ControllerBase } from './ControllerBase';
 import { IControllerBase } from './IControllerBase';
 
 @injectable()
-export class DappsStakingController implements IControllerBase {
+export class DappsStakingController extends ControllerBase implements IControllerBase {
     constructor(
         @inject('DappsStakingService') private _stakingService: IDappsStakingService,
         @inject('StatsIndexerService') private _indexerService: IStatsIndexerService,
-    ) {}
+    ) {
+        super();
+    }
 
     public register(app: express.Application): void {
         /**
@@ -25,7 +28,11 @@ export class DappsStakingController implements IControllerBase {
                     required: true
                 }
             */
-            res.json(await this._stakingService.calculateApr(req.params.network as NetworkType));
+            try {
+                res.json(await this._stakingService.calculateApr(req.params.network as NetworkType));
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**
@@ -40,7 +47,11 @@ export class DappsStakingController implements IControllerBase {
                     required: true
                 }
             */
-            res.json(await this._stakingService.calculateApy(req.params.network as NetworkType));
+            try {
+                res.json(await this._stakingService.calculateApy(req.params.network as NetworkType));
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**

--- a/src/controllers/TokenStatsController.ts
+++ b/src/controllers/TokenStatsController.ts
@@ -3,14 +3,17 @@ import { injectable, inject } from 'inversify';
 import { NetworkType } from '../networks';
 import { IStatsIndexerService, PeriodType } from '../services/StatsIndexerService';
 import { IStatsService } from '../services/StatsService';
+import { ControllerBase } from './ControllerBase';
 import { IControllerBase } from './IControllerBase';
 
 @injectable()
-export class TokenStatsController implements IControllerBase {
+export class TokenStatsController extends ControllerBase implements IControllerBase {
     constructor(
         @inject('StatsService') private _statsService: IStatsService,
         @inject('StatsIndexerService') private _indexerService: IStatsIndexerService,
-    ) {}
+    ) {
+        super();
+    }
 
     public register(app: express.Application): void {
         /**
@@ -18,7 +21,11 @@ export class TokenStatsController implements IControllerBase {
          */
         app.route('/api/token/stats').get(async (req: Request, res: Response) => {
             // #swagger.ignore = true
-            res.json(await this._statsService.getTokenStats());
+            try {
+                res.json(await this._statsService.getTokenStats());
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**
@@ -26,7 +33,11 @@ export class TokenStatsController implements IControllerBase {
          */
         app.route('/api/:network/token/stats').get(async (req: Request, res: Response) => {
             // #swagger.ignore = true
-            res.json(await this._statsService.getTokenStats(req.params.network as NetworkType));
+            try {
+                res.json(await this._statsService.getTokenStats(req.params.network as NetworkType));
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**
@@ -41,7 +52,11 @@ export class TokenStatsController implements IControllerBase {
                     required: true
                 }
             */
-            res.json(await this._statsService.getTokenStats(req.params.network as NetworkType));
+            try {
+                res.json(await this._statsService.getTokenStats(req.params.network as NetworkType));
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**
@@ -49,7 +64,11 @@ export class TokenStatsController implements IControllerBase {
          */
         app.route('/api/token/circulation').get(async (req: Request, res: Response) => {
             // #swagger.ignore = true
-            res.json(await (await this._statsService.getTokenStats()).circulatingSupply);
+            try {
+                res.json(await (await this._statsService.getTokenStats()).circulatingSupply);
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**
@@ -57,11 +76,15 @@ export class TokenStatsController implements IControllerBase {
          */
         app.route('/api/:network/token/circulation').get(async (req: Request, res: Response) => {
             // #swagger.ignore = true
-            res.json(
-                await (
-                    await this._statsService.getTokenStats(req.params.network as NetworkType)
-                ).circulatingSupply,
-            );
+            try {
+                res.json(
+                    await (
+                        await this._statsService.getTokenStats(req.params.network as NetworkType)
+                    ).circulatingSupply,
+                );
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**
@@ -76,11 +99,15 @@ export class TokenStatsController implements IControllerBase {
                     required: true
                 }
             */
-            res.json(
-                await (
-                    await this._statsService.getTokenStats(req.params.network as NetworkType)
-                ).circulatingSupply,
-            );
+            try {
+                res.json(
+                    await (
+                        await this._statsService.getTokenStats(req.params.network as NetworkType)
+                    ).circulatingSupply,
+                );
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
         });
 
         /**

--- a/src/services/DappsStakingService.ts
+++ b/src/services/DappsStakingService.ts
@@ -50,13 +50,21 @@ export class DappsStakingService implements IDappsStakingService {
             return stakerApr;
         } catch (e) {
             console.error(e);
-            return 0;
+            throw new Error(
+                'Unable to calculate network APR. Most likely there is an error fetching data from a node.',
+            );
         }
     }
 
     public async calculateApy(network = 'astar'): Promise<number> {
-        const apr = await this.calculateApr(network);
-        return aprToApy(apr);
+        try {
+            const apr = await this.calculateApr(network);
+            return aprToApy(apr);
+        } catch {
+            throw new Error(
+                'Unable to calculate network APY. Most likely there is an error fetching data from a node.',
+            );
+        }
     }
 
     private getAverageBlocksPerMins(chainId: string, data: AprCalculationData): number {

--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -41,7 +41,7 @@ export class StatsService implements IStatsService {
             );
         } catch (e) {
             console.error(e);
-            return new TokenStats(Math.floor(new Date().getTime() / 1000), 0, 0);
+            throw new Error('Unable to fetch token statistics from a node.');
         }
     }
 


### PR DESCRIPTION
Improved error handling to return error 500 instead of 0 value for all node calls (token stats, APR, APY).

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/8452361/164389618-afa1d09d-192c-490b-a8d1-234fa6c32a8d.png">
