### PR TITLE
Token price endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
     },
     "main": "build/index.js",
     "scripts": {
-        "start": " yarn swagger-autogen api.astar.network && yarn run serve",
-        "serve": "node build/index.js",
         "serve:firebase": "npm run build && firebase emulators:start --only functions",
         "shell:firebase": "npm run build && firebase functions:shell",
         "build": "yarn run build:swagger && tsc --project tsconfig.json",

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -12,6 +12,25 @@
     "https"
   ],
   "paths": {
+    "/api/v1/token/price/{symbol}": {
+      "get": {
+        "description": "Retrieves current token price",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Token symbol (eg. ASTR or SDN)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/v1/{network}/token/stats": {
       "get": {
         "description": "Retrieves token statistics for a given network.",

--- a/src/client/ApiFactory.ts
+++ b/src/client/ApiFactory.ts
@@ -1,5 +1,6 @@
 import { injectable } from 'inversify';
 import container from '../container';
+import { ContainerTypes } from '../containertypes';
 import { networks, NetworkType } from '../networks';
 import { IAstarApi } from './BaseApi';
 
@@ -11,11 +12,11 @@ export interface IApiFactory {
 export class ApiFactory implements IApiFactory {
     public getApiInstance(networkName: NetworkType): IAstarApi {
         try {
-            return container.getNamed<IAstarApi>('api', networkName);
+            return container.getNamed<IAstarApi>(ContainerTypes.Api, networkName);
         } catch {
             // fallback to Astar if invalid network name provided
             console.warn(`IAstarApi container for ${networkName} network not found. Falling back to Astar`);
-            return container.getNamed<IAstarApi>('api', networks.astar.name);
+            return container.getNamed<IAstarApi>(ContainerTypes.Api, networks.astar.name);
         }
     }
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -16,6 +16,10 @@ import { NodeController } from './controllers/NodeController';
 import { AstarApi2 } from './client/AstarApi2';
 import { FirebaseService, IFirebaseService } from './services/FirebaseService';
 import { ContainerTypes } from './containertypes';
+import { IPriceProvider } from './services/IPriceProvider';
+import { DiaDataPriceProvider } from './services/DiaDataPriceProvider';
+import { CoinGeckoPriceProvider } from './services/CoinGeckoPriceProvider';
+import { PriceProviderWithFailover } from './services/PriceProviderWithFailover';
 
 const container = new Container();
 
@@ -43,6 +47,12 @@ container.bind<IStatsService>(ContainerTypes.StatsService).to(StatsService).inSi
 container.bind<IDappsStakingService>(ContainerTypes.DappsStakingService).to(DappsStakingService).inSingletonScope();
 container.bind<IStatsIndexerService>(ContainerTypes.StatsIndexerService).to(StatsIndexerService).inSingletonScope();
 container.bind<IFirebaseService>(ContainerTypes.FirebaseService).to(FirebaseService).inSingletonScope();
+container.bind<IPriceProvider>(ContainerTypes.PriceProvider).to(DiaDataPriceProvider).inSingletonScope();
+container.bind<IPriceProvider>(ContainerTypes.PriceProvider).to(CoinGeckoPriceProvider).inSingletonScope();
+container
+    .bind<IPriceProvider>(ContainerTypes.PriceProviderWithFailover)
+    .to(PriceProviderWithFailover)
+    .inSingletonScope();
 
 // controllers registration
 container.bind<IControllerBase>(ContainerTypes.Controller).to(TokenStatsController);

--- a/src/container.ts
+++ b/src/container.ts
@@ -15,38 +15,34 @@ import { IStatsIndexerService, StatsIndexerService } from './services/StatsIndex
 import { NodeController } from './controllers/NodeController';
 import { AstarApi2 } from './client/AstarApi2';
 import { FirebaseService, IFirebaseService } from './services/FirebaseService';
-
-export const ContainerTypes = {
-    Controller: 'Controller',
-    StatsService: 'StatsService',
-};
+import { ContainerTypes } from './containertypes';
 
 const container = new Container();
 
 // data access
 container
-    .bind<IAstarApi>('api')
+    .bind<IAstarApi>(ContainerTypes.Api)
     .toConstantValue(new AstarApi2(networks.shiden.endpoint))
     .whenTargetNamed(networks.shiden.name);
 container
-    .bind<IAstarApi>('api')
+    .bind<IAstarApi>(ContainerTypes.Api)
     .toConstantValue(new AstarApi2(networks.astar.endpoint))
     .whenTargetNamed(networks.astar.name);
 container
-    .bind<IAstarApi>('api')
+    .bind<IAstarApi>(ContainerTypes.Api)
     .toConstantValue(new AstarApi2(networks.shibuya.endpoint))
     .whenTargetNamed(networks.shibuya.name);
 container
-    .bind<IAstarApi>('api')
+    .bind<IAstarApi>(ContainerTypes.Api)
     .toConstantValue(new AstarApi2(networks.development.endpoint))
     .whenTargetNamed(networks.development.name);
-container.bind<IApiFactory>('factory').to(ApiFactory).inSingletonScope();
+container.bind<IApiFactory>(ContainerTypes.ApiFactory).to(ApiFactory).inSingletonScope();
 
 // services registration
-container.bind<IStatsService>('StatsService').to(StatsService).inSingletonScope();
-container.bind<IDappsStakingService>('DappsStakingService').to(DappsStakingService).inSingletonScope();
-container.bind<IStatsIndexerService>('StatsIndexerService').to(StatsIndexerService).inSingletonScope();
-container.bind<IFirebaseService>('FirebaseService').to(FirebaseService).inSingletonScope();
+container.bind<IStatsService>(ContainerTypes.StatsService).to(StatsService).inSingletonScope();
+container.bind<IDappsStakingService>(ContainerTypes.DappsStakingService).to(DappsStakingService).inSingletonScope();
+container.bind<IStatsIndexerService>(ContainerTypes.StatsIndexerService).to(StatsIndexerService).inSingletonScope();
+container.bind<IFirebaseService>(ContainerTypes.FirebaseService).to(FirebaseService).inSingletonScope();
 
 // controllers registration
 container.bind<IControllerBase>(ContainerTypes.Controller).to(TokenStatsController);

--- a/src/containertypes.ts
+++ b/src/containertypes.ts
@@ -1,9 +1,11 @@
 export const ContainerTypes = {
-  Controller: 'Controller',
-  StatsService: 'StatsService',
-  Api: 'Api',
-  ApiFactory: 'ApiFactory',
-  DappsStakingService: 'DappsStakingService',
-  StatsIndexerService: 'StatsIndexerService',
-  FirebaseService: 'FirebaseService',
+    Controller: 'Controller',
+    StatsService: 'StatsService',
+    Api: 'Api',
+    ApiFactory: 'ApiFactory',
+    DappsStakingService: 'DappsStakingService',
+    StatsIndexerService: 'StatsIndexerService',
+    FirebaseService: 'FirebaseService',
+    PriceProvider: 'PriceProvider',
+    PriceProviderWithFailover: 'PriceProviderWithFailover',
 };

--- a/src/containertypes.ts
+++ b/src/containertypes.ts
@@ -1,0 +1,9 @@
+export const ContainerTypes = {
+  Controller: 'Controller',
+  StatsService: 'StatsService',
+  Api: 'Api',
+  ApiFactory: 'ApiFactory',
+  DappsStakingService: 'DappsStakingService',
+  StatsIndexerService: 'StatsIndexerService',
+  FirebaseService: 'FirebaseService',
+};

--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { injectable, inject } from 'inversify';
+import { ContainerTypes } from '../containertypes';
 import { NetworkType } from '../networks';
 import { IDappsStakingService } from '../services/DappsStakingService';
 import { IFirebaseService } from '../services/FirebaseService';
@@ -11,9 +12,9 @@ import { IControllerBase } from './IControllerBase';
 @injectable()
 export class DappsStakingController extends ControllerBase implements IControllerBase {
     constructor(
-        @inject('DappsStakingService') private _stakingService: IDappsStakingService,
-        @inject('StatsIndexerService') private _indexerService: IStatsIndexerService,
-        @inject('FirebaseService') private _firebaseService: IFirebaseService,
+        @inject(ContainerTypes.DappsStakingService) private _stakingService: IDappsStakingService,
+        @inject(ContainerTypes.StatsIndexerService) private _indexerService: IStatsIndexerService,
+        @inject(ContainerTypes.FirebaseService) private _firebaseService: IFirebaseService,
     ) {
         super();
     }

--- a/src/controllers/NodeController.ts
+++ b/src/controllers/NodeController.ts
@@ -1,12 +1,13 @@
 import express, { Request, Response } from 'express';
 import { injectable, inject } from 'inversify';
+import { ContainerTypes } from '../containertypes';
 import { NetworkType } from '../networks';
 import { IStatsIndexerService, PeriodType } from '../services/StatsIndexerService';
 import { IControllerBase } from './IControllerBase';
 
 @injectable()
 export class NodeController implements IControllerBase {
-    constructor(@inject('StatsIndexerService') private _indexerService: IStatsIndexerService) {}
+    constructor(@inject(ContainerTypes.StatsIndexerService) private _indexerService: IStatsIndexerService) {}
 
     public register(app: express.Application): void {
         /**

--- a/src/controllers/TokenStatsController.ts
+++ b/src/controllers/TokenStatsController.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import { injectable, inject } from 'inversify';
+import { ContainerTypes } from '../containertypes';
 import { NetworkType } from '../networks';
 import { IStatsIndexerService, PeriodType } from '../services/StatsIndexerService';
 import { IStatsService } from '../services/StatsService';
@@ -9,8 +10,8 @@ import { IControllerBase } from './IControllerBase';
 @injectable()
 export class TokenStatsController extends ControllerBase implements IControllerBase {
     constructor(
-        @inject('StatsService') private _statsService: IStatsService,
-        @inject('StatsIndexerService') private _indexerService: IStatsIndexerService,
+        @inject(ContainerTypes.StatsService) private _statsService: IStatsService,
+        @inject(ContainerTypes.StatsIndexerService) private _indexerService: IStatsIndexerService,
     ) {
         super();
     }

--- a/src/controllers/TokenStatsController.ts
+++ b/src/controllers/TokenStatsController.ts
@@ -51,7 +51,7 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.description = 'Retrieves current token price'
                 #swagger.parameters['symbol'] = {
                     in: 'path',
-                    description: 'Token symbol (eg. ASTR or SDN',
+                    description: 'Token symbol (eg. ASTR or SDN)',
                     required: true
                 }
             */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import * as functions from 'firebase-functions';
 import cors from 'cors';
-import container, { ContainerTypes } from './container';
+import container from './container';
 import { IControllerBase } from './controllers/IControllerBase';
+import { ContainerTypes } from './containertypes';
 
 const app = express();
 app.use(express.json({ limit: '5mb' }));

--- a/src/services/CoinGeckoPriceProvider.ts
+++ b/src/services/CoinGeckoPriceProvider.ts
@@ -5,7 +5,7 @@ import { IPriceProvider } from './IPriceProvider';
 /**
  * Provides token price by using Coin Gecko API
  */
- type CoinGeckoTokenInfo = { id: string; symbol: string; name: string };
+type CoinGeckoTokenInfo = { id: string; symbol: string; name: string };
 
 @injectable()
 export class CoinGeckoPriceProvider implements IPriceProvider {
@@ -16,31 +16,31 @@ export class CoinGeckoPriceProvider implements IPriceProvider {
         const tokenSymbol = await this.getTokenId(symbol);
 
         if (tokenSymbol) {
-          const url = `${CoinGeckoPriceProvider.BaseUrl}/simple/price?ids=${tokenSymbol}&vs_currencies=usd`;
-          const result = await axios.get(url);
+            const url = `${CoinGeckoPriceProvider.BaseUrl}/simple/price?ids=${tokenSymbol}&vs_currencies=usd`;
+            const result = await axios.get(url);
 
-          if (result.data[tokenSymbol]) {
-              const price = result.data[tokenSymbol].usd;
-              return Number(price);
-          }
+            if (result.data[tokenSymbol]) {
+                const price = result.data[tokenSymbol].usd;
+                return Number(price);
+            }
         }
 
         return 0;
     }
 
     private async getTokenId(symbol: string): Promise<string | undefined> {
-      if (!CoinGeckoPriceProvider.tokens) {
-        // Cache received data since token list is a quite big.
-        CoinGeckoPriceProvider.tokens = await this.getTokenList();
-      }
+        if (!CoinGeckoPriceProvider.tokens) {
+            // Cache received data since token list is a quite big.
+            CoinGeckoPriceProvider.tokens = await this.getTokenList();
+        }
 
-      return CoinGeckoPriceProvider.tokens.find(x => x.symbol.toLowerCase() === symbol.toLowerCase())?.id;
+        return CoinGeckoPriceProvider.tokens.find((x) => x.symbol.toLowerCase() === symbol.toLowerCase())?.id;
     }
 
     private async getTokenList(): Promise<CoinGeckoTokenInfo[]> {
-      const url = `${CoinGeckoPriceProvider.BaseUrl}/coins/list`;
-      const result = await axios.get<CoinGeckoTokenInfo[]>(url);
+        const url = `${CoinGeckoPriceProvider.BaseUrl}/coins/list`;
+        const result = await axios.get<CoinGeckoTokenInfo[]>(url);
 
-      return result.data;
+        return result.data;
     }
 }

--- a/src/services/CoinGeckoPriceProvider.ts
+++ b/src/services/CoinGeckoPriceProvider.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+import { injectable } from 'inversify';
+import { IPriceProvider } from './IPriceProvider';
+
+/**
+ * Provides token price by using Coin Gecko API
+ */
+ type CoinGeckoTokenInfo = { id: string; symbol: string; name: string };
+
+@injectable()
+export class CoinGeckoPriceProvider implements IPriceProvider {
+    public static BaseUrl = 'https://api.coingecko.com/api/v3';
+    private static tokens: CoinGeckoTokenInfo[];
+
+    public async getUsdPrice(symbol: string): Promise<number> {
+        const tokenSymbol = await this.getTokenId(symbol);
+
+        if (tokenSymbol) {
+          const url = `${CoinGeckoPriceProvider.BaseUrl}/simple/price?ids=${tokenSymbol}&vs_currencies=usd`;
+          const result = await axios.get(url);
+
+          if (result.data[tokenSymbol]) {
+              const price = result.data[tokenSymbol].usd;
+              return Number(price);
+          }
+        }
+
+        return 0;
+    }
+
+    private async getTokenId(symbol: string): Promise<string | undefined> {
+      if (!CoinGeckoPriceProvider.tokens) {
+        // Cache received data since token list is a quite big.
+        CoinGeckoPriceProvider.tokens = await this.getTokenList();
+      }
+
+      return CoinGeckoPriceProvider.tokens.find(x => x.symbol.toLowerCase() === symbol.toLowerCase())?.id;
+    }
+
+    private async getTokenList(): Promise<CoinGeckoTokenInfo[]> {
+      const url = `${CoinGeckoPriceProvider.BaseUrl}/coins/list`;
+      const result = await axios.get<CoinGeckoTokenInfo[]>(url);
+
+      return result.data;
+    }
+}

--- a/src/services/DappsStakingService.ts
+++ b/src/services/DappsStakingService.ts
@@ -9,6 +9,7 @@ import { DappItem, NewDappItem } from '../models/Dapp';
 import axios from 'axios';
 import { IFirebaseService } from './FirebaseService';
 import { IAstarApi, Transaction } from '../client/BaseApi';
+import { ContainerTypes } from '../containertypes';
 
 export interface IDappsStakingService {
     calculateApr(network?: NetworkType): Promise<number>;
@@ -34,8 +35,8 @@ const TS_FIRST_BLOCK = {
  */
 export class DappsStakingService implements IDappsStakingService {
     constructor(
-        @inject('factory') private _apiFactory: IApiFactory,
-        @inject('FirebaseService') private _firebase: IFirebaseService,
+        @inject(ContainerTypes.ApiFactory) private _apiFactory: IApiFactory,
+        @inject(ContainerTypes.FirebaseService) private _firebase: IFirebaseService,
     ) {}
 
     public async calculateApr(network = 'astar'): Promise<number> {

--- a/src/services/DiaDataPriceProvider.ts
+++ b/src/services/DiaDataPriceProvider.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { injectable } from 'inversify';
+import { IPriceProvider } from './IPriceProvider';
+
+/**
+ * Provides token price by using DIA Data API
+ */
+ @injectable()
+ export class DiaDataPriceProvider implements IPriceProvider {
+     public static BaseUrl = 'https://api.diadata.org/v1/quotation';
+ 
+     public async getUsdPrice(symbol: string): Promise<number> {
+         const url = `${DiaDataPriceProvider.BaseUrl}/${symbol}`;
+         const result = await axios.get(url);
+ 
+         if (result.data && result.data.Price) {
+             return Number(result.data.Price);
+         }
+ 
+         return 0;
+     }
+ }

--- a/src/services/DiaDataPriceProvider.ts
+++ b/src/services/DiaDataPriceProvider.ts
@@ -5,18 +5,18 @@ import { IPriceProvider } from './IPriceProvider';
 /**
  * Provides token price by using DIA Data API
  */
- @injectable()
- export class DiaDataPriceProvider implements IPriceProvider {
-     public static BaseUrl = 'https://api.diadata.org/v1/quotation';
- 
-     public async getUsdPrice(symbol: string): Promise<number> {
-         const url = `${DiaDataPriceProvider.BaseUrl}/${symbol}`;
-         const result = await axios.get(url);
- 
-         if (result.data && result.data.Price) {
-             return Number(result.data.Price);
-         }
- 
-         return 0;
-     }
- }
+@injectable()
+export class DiaDataPriceProvider implements IPriceProvider {
+    public static BaseUrl = 'https://api.diadata.org/v1/quotation';
+
+    public async getUsdPrice(symbol: string): Promise<number> {
+        const url = `${DiaDataPriceProvider.BaseUrl}/${symbol}`;
+        const result = await axios.get(url);
+
+        if (result.data && result.data.Price) {
+            return Number(result.data.Price);
+        }
+
+        return 0;
+    }
+}

--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -2,6 +2,7 @@ import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import { inject, injectable } from 'inversify';
 import { IApiFactory } from '../client/ApiFactory';
+import { ContainerTypes } from '../containertypes';
 import { DappItem, FileInfo, NewDappItem } from '../models/Dapp';
 import { NetworkType } from '../networks';
 
@@ -14,7 +15,7 @@ export interface IFirebaseService {
 export class FirebaseService implements IFirebaseService {
     private app: admin.app.App;
 
-    constructor(@inject('factory') private _apiFactory: IApiFactory) {}
+    constructor(@inject(ContainerTypes.ApiFactory) private _apiFactory: IApiFactory) {}
 
     public async getDapps(network: NetworkType = 'astar'): Promise<DappItem[]> {
         this.initApp();

--- a/src/services/IPriceProvider.ts
+++ b/src/services/IPriceProvider.ts
@@ -1,0 +1,10 @@
+/**
+ * Definition of provider for access token price.
+ */
+ export interface IPriceProvider {
+  /**
+   * Gets current token price in USD.
+   * @param tokenInfo Token information.
+   */
+  getUsdPrice(symbol: string): Promise<number>;
+}

--- a/src/services/IPriceProvider.ts
+++ b/src/services/IPriceProvider.ts
@@ -1,10 +1,10 @@
 /**
  * Definition of provider for access token price.
  */
- export interface IPriceProvider {
-  /**
-   * Gets current token price in USD.
-   * @param tokenInfo Token information.
-   */
-  getUsdPrice(symbol: string): Promise<number>;
+export interface IPriceProvider {
+    /**
+     * Gets current token price in USD.
+     * @param tokenInfo Token information.
+     */
+    getUsdPrice(symbol: string): Promise<number>;
 }

--- a/src/services/PriceProviderWithFailover.ts
+++ b/src/services/PriceProviderWithFailover.ts
@@ -1,0 +1,31 @@
+import { injectable } from 'inversify';
+import container from '../container';
+import { ContainerTypes } from '../containertypes';
+import { IPriceProvider } from './IPriceProvider';
+
+/**
+ * Uses registered price providers to fetch token price.
+ */
+ @injectable()
+ export class PriceProviderWithFailover implements IPriceProvider {
+     /**
+      * Fetches all registered price providers and tries to fetch data from a first one.
+      * If call fails it moves to second price provider and so on.
+      * @param tokenInfo Token information.
+      * @returns Token price or 0 if unable to fetch price.
+      */
+     public async getUsdPrice(symbol: string): Promise<number> {
+         const providers = container.getAll<IPriceProvider>(ContainerTypes.PriceProvider);
+ 
+         for (const provider of providers) {
+             try {
+                 return await provider.getUsdPrice(symbol);
+             } catch (error) {
+                 // execution will move to next price provider
+                 console.log(error);
+             }
+         }
+ 
+         return 0;
+     }
+ }

--- a/src/services/PriceProviderWithFailover.ts
+++ b/src/services/PriceProviderWithFailover.ts
@@ -6,26 +6,26 @@ import { IPriceProvider } from './IPriceProvider';
 /**
  * Uses registered price providers to fetch token price.
  */
- @injectable()
- export class PriceProviderWithFailover implements IPriceProvider {
-     /**
-      * Fetches all registered price providers and tries to fetch data from a first one.
-      * If call fails it moves to second price provider and so on.
-      * @param tokenInfo Token information.
-      * @returns Token price or 0 if unable to fetch price.
-      */
-     public async getUsdPrice(symbol: string): Promise<number> {
-         const providers = container.getAll<IPriceProvider>(ContainerTypes.PriceProvider);
- 
-         for (const provider of providers) {
-             try {
-                 return await provider.getUsdPrice(symbol);
-             } catch (error) {
-                 // execution will move to next price provider
-                 console.log(error);
-             }
-         }
- 
-         return 0;
-     }
- }
+@injectable()
+export class PriceProviderWithFailover implements IPriceProvider {
+    /**
+     * Fetches all registered price providers and tries to fetch data from a first one.
+     * If call fails it moves to second price provider and so on.
+     * @param tokenInfo Token information.
+     * @returns Token price or 0 if unable to fetch price.
+     */
+    public async getUsdPrice(symbol: string): Promise<number> {
+        const providers = container.getAll<IPriceProvider>(ContainerTypes.PriceProvider);
+
+        for (const provider of providers) {
+            try {
+                return await provider.getUsdPrice(symbol);
+            } catch (error) {
+                // execution will move to next price provider
+                console.log(error);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/services/StatsIndexerService.ts
+++ b/src/services/StatsIndexerService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { ethers } from 'ethers';
 import { inject, injectable } from 'inversify';
 import { IApiFactory } from '../client/ApiFactory';
+import { ContainerTypes } from '../containertypes';
 import { NetworkType } from '../networks';
 import { getDateUTC, getDateYyyyMmDd, getSubscanUrl, getSubscanOption } from '../utils';
 
@@ -33,7 +34,7 @@ const API_URLS_TVL = {
  * Fetches statistics from external data source
  */
 export class StatsIndexerService implements IStatsIndexerService {
-    constructor(@inject('factory') private _apiFactory: IApiFactory) {}
+    constructor(@inject(ContainerTypes.ApiFactory) private _apiFactory: IApiFactory) {}
 
     public async getDappStakingTvl(network: NetworkType, period: PeriodType): Promise<Pair[]> {
         if (network !== 'astar' && network !== 'shiden') {

--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -2,6 +2,7 @@ import { PalletBalancesAccountData } from '@polkadot/types/lookup';
 import { formatBalance, BN } from '@polkadot/util';
 import { injectable, inject } from 'inversify';
 import { IApiFactory } from '../client/ApiFactory';
+import { ContainerTypes } from '../containertypes';
 import { TokenStats } from '../models/TokenStats';
 import { NetworkType } from '../networks';
 import { addressesToExclude } from './AddressesToExclude';
@@ -15,7 +16,7 @@ export interface IStatsService {
  * Token statistics calculation service.
  */
 export class StatsService implements IStatsService {
-    constructor(@inject('factory') private _apiFactory: IApiFactory) {}
+    constructor(@inject(ContainerTypes.ApiFactory) private _apiFactory: IApiFactory) {}
 
     /**
      * Calculates token circulation supply by substracting sum of all token holder accounts


### PR DESCRIPTION
Added token price endpoint to the API and refactored IoC container registration by removing string literals.

The logic used for price fetching is very similar to one I created a few days ago for UI. https://github.com/AstarNetwork/astar-apps/pull/461

To test the endpoint append `api/v1/token/price/` to the staging url and add token symbol at the end (eg. `api/v1/token/price/SDN`)