### PR TITLE
fix typo in function  next network index

### DIFF
--- a/src/client/BaseApi.ts
+++ b/src/client/BaseApi.ts
@@ -161,7 +161,7 @@ export class BaseApi implements IAstarApi {
             async () => {
                 // Connection failed.
                 localApi.disconnect(); //Stop reconnecting to failed endpoint.
-                const nextNetworkIndex = this.getNetxtNetworkIndex(currentIndex);
+                const nextNetworkIndex = this.getNextNetworkIndex(currentIndex);
                 console.warn(
                     `Connection to ${this.endpoints[currentIndex]} failed. Falling back to ${this.endpoints[nextNetworkIndex]}`,
                 );
@@ -172,7 +172,7 @@ export class BaseApi implements IAstarApi {
         );
     }
 
-    private getNetxtNetworkIndex(currentIndex: number): number {
+    private getNextNetworkIndex(currentIndex: number): number {
         return (currentIndex + 1) % this.endpoints.length;
     }
 


### PR DESCRIPTION
Fixed typo that was mentioned on this comment https://github.com/AstarNetwork/astar-token-api/pull/36#discussion_r928874340

I accidentally merged it before fixing :(