### PR TITLE
Temporary disable developer social account link validation.

### DIFF
--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -318,6 +318,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
 }
 
 export function validateDeveloperLinks(developer: Developer): boolean {
+    return true;
+
     const httpRegex =
         /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
 

--- a/tests/controllers/DappsStakingController.spec.ts
+++ b/tests/controllers/DappsStakingController.spec.ts
@@ -36,17 +36,17 @@ describe('validateDeveloperLinks', () => {
         developer.linkedInAccountUrl = 'https://test.com';
         developer.twitterAccountUrl = 'invalid';
 
-        expect(validateDeveloperLinks(developer)).toBeFalsy();
+        expect(validateDeveloperLinks(developer)).toBeTruthy();
     });
 
     it('fails if developer has invalid LinkedIn link', () => {
         developer.twitterAccountUrl = 'https://test.com';
         developer.linkedInAccountUrl = 'invalid';
 
-        expect(validateDeveloperLinks(developer)).toBeFalsy();
+        expect(validateDeveloperLinks(developer)).toBeTruthy();
     });
 
     it('fails if links are empty', () => {
-        expect(validateDeveloperLinks(developer)).toBeFalsy();
+        expect(validateDeveloperLinks(developer)).toBeTruthy();
     });
 });


### PR DESCRIPTION
Temporary disabled developer url validation because of suspicious regex used in order to avoid ReDoS attack. This validation is used in dapp registration process.
Idea is to come with better regex or find reliable 3rd party validation library (more likely to be used)