### PR TITLE
Dapp radar caching fix

### DIFF
--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -125,7 +125,8 @@ export class FirebaseService implements IFirebaseService {
         Guard.ThrowIfUndefined('item', item);
 
         this.initApp();
-        await admin.firestore().collection(this.cacheCollectionKey).doc(key).set({ data: item });
+        const updatedAt = new Date().getTime();
+        await admin.firestore().collection(this.cacheCollectionKey).doc(key).set({ data: item, updatedAt });
     }
 
     public async readCache<T>(key: string): Promise<Cache<T> | undefined> {


### PR DESCRIPTION
Figured out that DappRadar caching is not working properly because cache update time was not stored to the cache