### PR TITLE
getCollectionKey update

### DIFF
--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -174,6 +174,9 @@ export class FirebaseService implements IFirebaseService {
         if (network.toString() === 'development') {
             // special case so we can test dapps staking on a local node.
             return 'development-dapps';
+        } else if (network.toString().includes('testnet')) {
+            // another special case when testing with Zombienet
+            return network.toString().replace(' ', '-').toLowerCase();
         }
 
         const api = this._apiFactory.getApiInstance(network);


### PR DESCRIPTION
Updated `getCollectionKey` method to return firebase keys to be used when testing with Zombienet (ie `astar-testnet` or `shiden-testnet`