### PR TITLE
Refactor API Endpoints 

### DIFF
--- a/public/swagger.json
+++ b/public/swagger.json
@@ -8,7 +8,6 @@
   "host": "api.astar.network",
   "basePath": "/",
   "schemes": [
-    "http",
     "https"
   ],
   "paths": {
@@ -24,7 +23,11 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Token symbol (eg. ASTR or SDN)"
+            "description": "Token symbol (eg. ASTR or SDN)",
+            "enum": [
+              "ASTR",
+              "SDN"
+            ]
           }
         ],
         "responses": {
@@ -46,7 +49,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -68,7 +77,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -90,14 +105,26 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "period",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year"
+            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year",
+            "enum": [
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
           }
         ],
         "responses": {
@@ -119,14 +146,26 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "period",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year"
+            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year",
+            "enum": [
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
           }
         ],
         "responses": {
@@ -148,7 +187,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -170,7 +215,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -192,7 +243,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -214,14 +271,26 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "period",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year"
+            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year",
+            "enum": [
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
           }
         ],
         "responses": {
@@ -243,7 +312,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "address",
@@ -272,7 +347,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar, development"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar, development",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -294,7 +375,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar, development"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar, development",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "address",
@@ -323,7 +410,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar, development"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar, development",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar",
+              "development"
+            ]
           }
         ],
         "responses": {
@@ -348,7 +442,11 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden"
+            "description": "The network name. Supported networks: astar, shiden",
+            "enum": [
+              "astar",
+              "shiden"
+            ]
           },
           {
             "name": "contractAddress",
@@ -362,7 +460,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Period to get stats for. Supported periods: 7 eras, 30 eras, 90 eras, all"
+            "description": "Period to get stats for. Supported periods: 7 eras, 30 eras, 90 eras, all",
+            "enum": [
+              "7 eras",
+              "30 eras",
+              "90 eras",
+              "all"
+            ]
           }
         ],
         "responses": {
@@ -384,7 +488,11 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden"
+            "description": "The network name. Supported networks: astar, shiden",
+            "enum": [
+              "astar",
+              "shiden"
+            ]
           },
           {
             "name": "userAddress",
@@ -398,7 +506,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year"
+            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year",
+            "enum": [
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
           }
         ],
         "responses": {
@@ -503,7 +617,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           }
         ],
         "responses": {
@@ -525,14 +645,26 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "period",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year"
+            "description": "The period type. Supported values: 7 days 30 days, 90 days, 1 year",
+            "enum": [
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
           }
         ],
         "responses": {
@@ -554,7 +686,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "hash",
@@ -583,7 +721,13 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar"
+            "description": "The network name. Supported networks: astar, shiden, shibuya, rocstar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya",
+              "rocstar"
+            ]
           },
           {
             "name": "senderAddress",
@@ -619,14 +763,21 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar"
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar"
+            ]
           },
           {
             "name": "period",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days, 30 days"
+            "description": "The period type. Supported values: 7 days, 30 days",
+            "enum": [
+              "7 days",
+              "30 days"
+            ]
           }
         ],
         "responses": {
@@ -648,14 +799,21 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar"
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar"
+            ]
           },
           {
             "name": "period",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The period type. Supported values: 7 days, 30 days"
+            "description": "The period type. Supported values: 7 days, 30 days",
+            "enum": [
+              "7 days",
+              "30 days"
+            ]
           }
         ],
         "responses": {
@@ -677,7 +835,10 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The network name. Supported networks: astar"
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar"
+            ]
           },
           {
             "name": "numberOfMonths",

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -8,7 +8,8 @@
   "host": "api.astar.network",
   "basePath": "/",
   "schemes": [
-    "https"
+    "https",
+    "http"
   ],
   "paths": {
     "/api/v1/token/price/{symbol}": {

--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -36,7 +36,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
             */
             try {
@@ -61,7 +62,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
             */
             try {
@@ -86,12 +88,14 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'The period type. Supported values: 7 days 30 days, 90 days, 1 year',
                     required: true,
+                    enum: ['7 days', '30 days', '90 days', '1 year']
                 }
             */
             res.json(
@@ -112,7 +116,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['address'] = {
                     in: 'path',
@@ -135,7 +140,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar, development',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
             */
             res.json(await this._firebaseService.getDapps(req.params.network as NetworkType));
@@ -148,7 +154,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar, development',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['address'] = {
                     in: 'path',
@@ -211,7 +218,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                     #swagger.parameters['network'] = {
                         in: 'path',
                         description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar, development',
-                        required: true
+                        required: true,
+                        enum: ['astar', 'shiden', 'shibuya', 'rocstar', 'development']
                     }
                 */
 
@@ -242,7 +250,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden']
                 }
                 #swagger.parameters['contractAddress'] = {
                     in: 'path',
@@ -252,7 +261,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'Period to get stats for. Supported periods: 7 eras, 30 eras, 90 eras, all',
-                    required: true
+                    required: true,
+                    enum: ['7 eras', '30 eras', '90 eras', 'all']
                 }
             */
                 res.json(
@@ -273,7 +283,8 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden']
                 }
                 #swagger.parameters['userAddress'] = {
                     in: 'path',
@@ -284,6 +295,7 @@ export class DappsStakingController extends ControllerBase implements IControlle
                     in: 'path',
                     description: 'The period type. Supported values: 7 days 30 days, 90 days, 1 year',
                     required: true,
+                    enum: ['7 days', '30 days', '90 days', '1 year']
                 }
             */
                 res.json(

--- a/src/controllers/MonthlyActiveWalletsController.ts
+++ b/src/controllers/MonthlyActiveWalletsController.ts
@@ -22,12 +22,14 @@ export class MonthlyActiveWalletsController extends ControllerBase implements IC
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar',
-                    required: true
+                    required: true,
+                    enum: ['astar']
                 }
                 #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'The period type.  Supported values: 7 days, 30 days',
                     required: true,
+                    enum: ['7 days', '30 days']
                 }
             */
 
@@ -54,12 +56,14 @@ export class MonthlyActiveWalletsController extends ControllerBase implements IC
               #swagger.parameters['network'] = {
                   in: 'path',
                   description: 'The network name. Supported networks: astar',
-                  required: true
+                  required: true,
+                  enum: ['astar']
               }
               #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'The period type.  Supported values: 7 days, 30 days',
                     required: true,
+                    enum: ['7 days', '30 days']
                 }
           */
 
@@ -80,7 +84,8 @@ export class MonthlyActiveWalletsController extends ControllerBase implements IC
             #swagger.parameters['network'] = {
                 in: 'path',
                 description: 'The network name. Supported networks: astar',
-                required: true
+                required: true,
+                enum: ['astar']
             }
             #swagger.parameters['numberOfMonths'] = {
                 in: 'path',

--- a/src/controllers/NodeController.ts
+++ b/src/controllers/NodeController.ts
@@ -21,7 +21,8 @@ export class NodeController implements IControllerBase {
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
             */
             res.json(await this._indexerService.getTotalTransfers(req.params.network as NetworkType));
@@ -34,12 +35,14 @@ export class NodeController implements IControllerBase {
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'The period type.  Supported values: 7 days 30 days, 90 days, 1 year',
                     required: true,
+                    enum: ['7 days', '30 days', '90 days', '1 year']
                 }
             */
             res.json(

--- a/src/controllers/TokenStatsController.ts
+++ b/src/controllers/TokenStatsController.ts
@@ -54,7 +54,8 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.parameters['symbol'] = {
                     in: 'path',
                     description: 'Token symbol (eg. ASTR or SDN)',
-                    required: true
+                    required: true,
+                    enum: ['ASTR', 'SDN']
                 }
             */
             try {
@@ -74,7 +75,8 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
             */
             try {
@@ -122,7 +124,8 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
             */
             try {
@@ -146,12 +149,14 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'The period type.  Supported values: 7 days 30 days, 90 days, 1 year',
                     required: true,
+                    enum: ['7 days', '30 days', '90 days', '1 year']
                 }
             */
             res.json(
@@ -169,12 +174,14 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['period'] = {
                     in: 'path',
                     description: 'The period type.  Supported values: 7 days 30 days, 90 days, 1 year',
                     required: true,
+                    enum: ['7 days', '30 days', '90 days', '1 year']
                 }
             */
             res.json(
@@ -192,7 +199,8 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                         #swagger.parameters['network'] = {
                             in: 'path',
                             description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                            required: true
+                            required: true,
+                            enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                         }
                     */
             res.json(await this._indexerService.getHolders(req.params.network as NetworkType));

--- a/src/controllers/TxQueryController.ts
+++ b/src/controllers/TxQueryController.ts
@@ -23,7 +23,8 @@ export class TxQueryController extends ControllerBase implements IControllerBase
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['hash'] = {
                     in: 'query',
@@ -47,7 +48,8 @@ export class TxQueryController extends ControllerBase implements IControllerBase
                 #swagger.parameters['network'] = {
                     in: 'path',
                     description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar',
-                    required: true
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
                 }
                 #swagger.parameters['senderAddress'] = {
                     in: 'query',

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -16,7 +16,7 @@ const getDocumentation = (host) => ({
         description: 'Provides network statistic information.',
     },
     host: host ? host : 'localhost:3000',
-    schemes: ['http', 'https'],
+    schemes: ['https'],
 });
 
 const args = process.argv.slice(2); // first two args are 'node' and command name

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -16,7 +16,7 @@ const getDocumentation = (host) => ({
         description: 'Provides network statistic information.',
     },
     host: host ? host : 'localhost:3000',
-    schemes: ['https'],
+    schemes: ['https', 'http'],
 });
 
 const args = process.argv.slice(2); // first two args are 'node' and command name


### PR DESCRIPTION


1 - The "HTTP" schema has been removed because the endpoint api.astar.network automatically redirects from port 80 to 443, making the HTTP schema unnecessary.
Previously, "HTTP" was the default schema, which consistently resulted in errors when querying the API endpoints.
Error: Undocumented - TypeError: NetworkError when attempting to fetch resource.

2 - Refactor API Endpoints to Replace Textfields with Enum Parameters
This pull request introduces a significant enhancement to our API endpoints by replacing all textfield inputs with enum parameters. This change is aimed at improving the user experience and reducing potential errors.

Previously, our API endpoints accepted general string inputs, which could lead to potential errors or confusion if an unsupported or incorrect value was entered. With this update, we are replacing these open textfields with dropdown selections, where users can only choose from a predefined set of options.

This change enforces stricter input validation across all endpoints, thereby improving the robustness and reliability of our API. It also simplifies the user interaction, as users can now select from available options rather than manually inputting values.

The changes have been implemented across all API endpoints. Each endpoint's Swagger definition has been updated to reflect these changes, with the 'type' of relevant parameters changed from 'string' to 'enum', and the acceptable values defined accordingly.

Missing network information, which endpoints are allowed, for the following urls:
/api/v1/{network}/dapps-staking/stats/transactions
/api/v1/{network}/dapps-staking/stats/uaw
/api/v1/{network}/dapps-staking/stats/nexteraeta

@bobo-k2
