### PR TITLE
Fetch aggregated stats from dApp radar

### DIFF
--- a/public/swagger.json
+++ b/public/swagger.json
@@ -14,6 +14,9 @@
   "paths": {
     "/api/v1/token/price/{symbol}": {
       "get": {
+        "tags": [
+          "Token"
+        ],
         "description": "Retrieves current token price",
         "parameters": [
           {
@@ -142,6 +145,9 @@
     },
     "/api/v1/{network}/dapps-staking/apr": {
       "get": {
+        "tags": [
+          "Dapps Staking"
+        ],
         "description": "Retrieves dapp staking APR for a given network.",
         "parameters": [
           {
@@ -363,6 +369,80 @@
         }
       }
     },
+    "/api/v1/{network}/dapps-staking/stats/transactions": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "dappName",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "dappUrl",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/{network}/dapps-staking/stats/uaw": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "dappName",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "dappUrl",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/{network}/dapps-staking/stats/nexteraeta": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/v1/{network}/node/tx-perblock/total": {
       "get": {
         "description": "Retreives total (valid and failed) number of transfers (number of balance.Transfer events).",
@@ -436,7 +516,7 @@
     },
     "/api/v1/{network}/tx/xvm-transfer": {
       "get": {
-        "description": "Return the transfer transaction detail of a given hash",
+        "description": "Return the xvm-transfer transactionhistory of a given sender and contract address",
         "parameters": [
           {
             "name": "network",
@@ -448,16 +528,16 @@
           {
             "name": "senderAddress",
             "in": "query",
+            "description": "SS58 wallet address",
             "required": true,
-            "type": "string",
-            "description": "SS58 wallet address"
+            "type": "string"
           },
           {
             "name": "contractAddress",
             "in": "query",
+            "description": "SS58 XVM Transfer contract address",
             "required": true,
-            "type": "string",
-            "description": "SS58 XVM Transfer contract address"
+            "type": "string"
           }
         ],
         "responses": {

--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -358,20 +358,18 @@ export class DappsStakingController extends ControllerBase implements IControlle
             }
         });
 
-        app.route('/api/v1/:network/dapps-staking/stats/aggregated').get(
-            async (req: Request, res: Response) => {
-                try {
-                    res.json(
-                        await this._dappRadarService.getAggregatedData(
-                            req.params.network as NetworkType,
-                            req.query.period as string,
-                        ),
-                    );
-                } catch (err) {
-                    this.handleError(res, err as Error);
-                }
-            },
-        );
+        app.route('/api/v1/:network/dapps-staking/stats/aggregated').get(async (req: Request, res: Response) => {
+            try {
+                res.json(
+                    await this._dappRadarService.getAggregatedData(
+                        req.params.network as NetworkType,
+                        req.query.period as string,
+                    ),
+                );
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
+        });
     }
 }
 

--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -230,23 +230,23 @@ export class DappsStakingController extends ControllerBase implements IControlle
         app.route('/api/v1/:network/dapps-staking/stats/dapp/:contractAddress/:period').get(
             async (req: Request, res: Response) => {
                 /*
-                #swagger.description = 'Retrieves number of calls and unique users per era statistics.'
-                #swagger.parameters['network'] = {
-                    in: 'path',
-                    description: 'The network name. Supported networks: astar, shiden',
-                    required: true
-                }
-                #swagger.parameters['contractAddress'] = {
-                    in: 'path',
-                    description: 'Contract address to get stats for',
-                    required: true
-                }
-                #swagger.parameters['period'] = {
-                    in: 'path',
-                    description: 'Period to get stats for. Supported periods: 7 eras, 30 eras, 90 eras, all',
-                    required: true
-                }
-            */
+                    #swagger.description = 'Retrieves number of calls and unique users per era statistics.'
+                    #swagger.parameters['network'] = {
+                        in: 'path',
+                        description: 'The network name. Supported networks: astar, shiden',
+                        required: true
+                    }
+                    #swagger.parameters['contractAddress'] = {
+                        in: 'path',
+                        description: 'Contract address to get stats for',
+                        required: true
+                    }
+                    #swagger.parameters['period'] = {
+                        in: 'path',
+                        description: 'Period to get stats for. Supported periods: 7 eras, 30 eras, 90 eras, all',
+                        required: true
+                    }
+                */
                 res.json(
                     await this._statsService.getContractStatistics(
                         req.params.network as NetworkType,
@@ -260,23 +260,23 @@ export class DappsStakingController extends ControllerBase implements IControlle
         app.route('/api/v1/:network/dapps-staking/stats/user/:userAddress/:period').get(
             async (req: Request, res: Response) => {
                 /*
-                #swagger.description = 'Retrieves user transactions.'
-                #swagger.parameters['network'] = {
-                    in: 'path',
-                    description: 'The network name. Supported networks: astar, shiden',
-                    required: true
-                }
-                #swagger.parameters['userAddress'] = {
-                    in: 'path',
-                    description: 'User address to get stats for',
-                    required: true
-                }
-                #swagger.parameters['period'] = {
-                    in: 'path',
-                    description: 'The period type. Supported values: 7 days 30 days, 90 days, 1 year',
-                    required: true,
-                }
-            */
+                    #swagger.description = 'Retrieves user transactions.'
+                    #swagger.parameters['network'] = {
+                        in: 'path',
+                        description: 'The network name. Supported networks: astar, shiden',
+                        required: true
+                    }
+                    #swagger.parameters['userAddress'] = {
+                        in: 'path',
+                        description: 'User address to get stats for',
+                        required: true
+                    }
+                    #swagger.parameters['period'] = {
+                        in: 'path',
+                        description: 'The period type. Supported values: 7 days 30 days, 90 days, 1 year',
+                        required: true,
+                    }
+                */
                 res.json(
                     await this._statsService.getUserEvents(
                         req.params.network as NetworkType,
@@ -327,6 +327,21 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 this.handleError(res, err as Error);
             }
         });
+
+        app.route('/api/v1/:network/dapps-staking/stats/aggregated').get(
+            async (req: Request, res: Response) => {
+                try {
+                    res.json(
+                        await this._dappRadarService.getAggregatedData(
+                            req.params.network as NetworkType,
+                            req.query.period as string,
+                        ),
+                    );
+                } catch (err) {
+                    this.handleError(res, err as Error);
+                }
+            },
+        );
     }
 }
 

--- a/src/services/DappRadarService.ts
+++ b/src/services/DappRadarService.ts
@@ -199,12 +199,6 @@ export class DappRadarService {
 
         // In some cases dapp name in dapp staking and in dapp radar are not exactly the same, so idea to check if
         // name or dapp url match. If both are different most likely the dapp will need to update name or url in dapp staking.
-
-        // Remove trailing slash from dapp url.
-        if (dappUrl.endsWith('/')) {
-            dappUrl = dappUrl.slice(0, -1);
-        }
-
         return dapps.find(
             (x) =>
                 x.name.toLowerCase() === dappName.toLowerCase() ||

--- a/src/services/DappRadarService.ts
+++ b/src/services/DappRadarService.ts
@@ -17,6 +17,7 @@ export interface IDappRadarService {
 interface ApiResponse<T> {
     success: boolean;
     results: T[];
+    pageCount: number;
 }
 
 interface AggregatedMetrics {
@@ -44,19 +45,19 @@ enum DappRadarMetricType {
 @injectable()
 export class DappRadarService {
     public static BaseUrl = 'https://api.dappradar.com/97c1ov0nxxr0jjh8/';
+    readonly RESULTS_PER_PAGE = 50;
 
     constructor(@inject(ContainerTypes.FirebaseService) private firebase: IFirebaseService) {}
 
     public async getDapps(network: NetworkType): Promise<Dapp[]> {
         const result: Dapp[] = [];
         let currentPage = 1;
-        const RESULTS_PER_PAGE = 50;
 
         // Dapps request is paged so we need to fetch all pages.
         do {
             const url = `${
                 DappRadarService.BaseUrl
-            }/dapps?chain=${network.toLowerCase()}&page=${currentPage}&resultsPerPage=${RESULTS_PER_PAGE}`;
+            }/dapps?chain=${network.toLowerCase()}&page=${currentPage}&resultsPerPage=${this.RESULTS_PER_PAGE}`;
 
             try {
                 const response = await axios.get<ApiResponse<Dapp>>(url, {
@@ -132,24 +133,44 @@ export class DappRadarService {
     }
 
     public async getAggregatedData(network: NetworkType, period: string): Promise<AggregatedMetrics[]> {
-        const url = `${
-            DappRadarService.BaseUrl
-        }/dapps/aggregated/metrics?chain=${network.toLowerCase()}&range=${period}`;
-        const response = await axios.get<ApiResponse<AggregatedMetrics>>(url, {
-            headers: { 'X-BLOBR-KEY': `${functions.config().dappradar.apikey}` },
-        });
+        let result: AggregatedMetrics[] = [];
+        let currentPage = 1;
 
-        if (response.data.success) {
-            // Add url to result.
-            const cachedDapps = await this.getDappsFromCache(network);
-            return response.data.results.map((result) => {
-                return {
-                    ...result,
-                    url: cachedDapps.find((dapp) => dapp.dappId === result.dappId)?.website ?? '',
-                };
-            });
-        }
-        return [];
+        do {
+            try {
+                const url = `${
+                    DappRadarService.BaseUrl
+                }/dapps/aggregated/metrics?chain=${network.toLowerCase()}&range=${period}&resultsPerPage=${
+                    this.RESULTS_PER_PAGE
+                }&page=${currentPage}`;
+                const response = await axios.get<ApiResponse<AggregatedMetrics>>(url, {
+                    headers: { 'X-BLOBR-KEY': `${functions.config().dappradar.apikey}` },
+                });
+
+                if (response.data.success) {
+                    // Add url to result.
+                    const cachedDapps = await this.getDappsFromCache(network);
+                    result.push(
+                        ...response.data.results.map((result) => {
+                            return {
+                                ...result,
+                                url: cachedDapps.find((dapp) => dapp.dappId === result.dappId)?.website ?? '',
+                            };
+                        }),
+                    );
+                }
+
+                if (currentPage === response.data.pageCount) {
+                    break;
+                }
+
+                currentPage++;
+            } catch {
+                break;
+            }
+        } while (true);
+
+        return result;
     }
 
     private async getMetricHistory(
@@ -178,9 +199,31 @@ export class DappRadarService {
 
         // In some cases dapp name in dapp staking and in dapp radar are not exactly the same, so idea to check if
         // name or dapp url match. If both are different most likely the dapp will need to update name or url in dapp staking.
+
+        // Remove trailing slash from dapp url.
+        if (dappUrl.endsWith('/')) {
+            dappUrl = dappUrl.slice(0, -1);
+        }
+
         return dapps.find(
-            (x) => x.name.toLowerCase() === dappName.toLowerCase() || x.website.toLowerCase() === dappUrl.toLowerCase(),
+            (x) =>
+                x.name.toLowerCase() === dappName.toLowerCase() ||
+                this.getDomain(x.website.toLowerCase()) === this.getDomain(dappUrl.toLowerCase()),
         )?.dappId;
+    }
+
+    private getDomain(url: string): string | null {
+        var prefix = /^https?:\/\//i;
+        var domain = /^[^\/:]+/;
+        // Remove any prefix
+        url = url.replace(prefix, '');
+        // Extract just the domain
+        var match = url.match(domain);
+        if (match) {
+            return match[0];
+        }
+        
+        return null;
     }
 
     private getCacheKey(network: NetworkType): string {

--- a/src/services/DappRadarService.ts
+++ b/src/services/DappRadarService.ts
@@ -133,7 +133,7 @@ export class DappRadarService {
     }
 
     public async getAggregatedData(network: NetworkType, period: string): Promise<AggregatedMetrics[]> {
-        let result: AggregatedMetrics[] = [];
+        const result: AggregatedMetrics[] = [];
         let currentPage = 1;
 
         do {
@@ -207,16 +207,16 @@ export class DappRadarService {
     }
 
     private getDomain(url: string): string | null {
-        var prefix = /^https?:\/\//i;
-        var domain = /^[^\/:]+/;
+        const prefix = /^https?:\/\//i;
+        const domain = /^[^\/:]+/;
         // Remove any prefix
         url = url.replace(prefix, '');
         // Extract just the domain
-        var match = url.match(domain);
+        const match = url.match(domain);
         if (match) {
             return match[0];
         }
-        
+
         return null;
     }
 


### PR DESCRIPTION
Provide dApp Radar aggregated data through Token API so the data can be used on the portal.