### PR TITLE
Improved parameters check for all public DappRadarService methods

### DIFF
--- a/src/services/DappRadarService.ts
+++ b/src/services/DappRadarService.ts
@@ -50,6 +50,9 @@ export class DappRadarService {
     constructor(@inject(ContainerTypes.FirebaseService) private firebase: IFirebaseService) {}
 
     public async getDapps(network: NetworkType): Promise<Dapp[]> {
+        Guard.ThrowIfUndefined('network', network);
+        this.ThrowIfNetworkNotSupported(network);
+
         const result: Dapp[] = [];
         let currentPage = 1;
 
@@ -118,6 +121,7 @@ export class DappRadarService {
         Guard.ThrowIfUndefined('dappName', dappName);
         Guard.ThrowIfUndefined('dappUrl', dappUrl);
         Guard.ThrowIfUndefined('network', network);
+        this.ThrowIfNetworkNotSupported(network);
 
         const dappId = await this.getDappId(dappName, dappUrl, network);
         return await this.getMetricHistory(dappId, network, DappRadarMetricType.Transactions);
@@ -127,12 +131,17 @@ export class DappRadarService {
         Guard.ThrowIfUndefined('dappName', dappName);
         Guard.ThrowIfUndefined('dappUrl', dappUrl);
         Guard.ThrowIfUndefined('network', network);
+        this.ThrowIfNetworkNotSupported(network);
 
         const dappId = await this.getDappId(dappName, dappUrl, network);
         return await this.getMetricHistory(dappId, network, DappRadarMetricType.UniqueActiveWallets);
     }
 
     public async getAggregatedData(network: NetworkType, period: string): Promise<AggregatedMetrics[]> {
+        Guard.ThrowIfUndefined('network', network);
+        Guard.ThrowIfUndefined('period', period);
+        this.ThrowIfNetworkNotSupported(network);
+
         const result: AggregatedMetrics[] = [];
         let currentPage = 1;
 
@@ -222,5 +231,11 @@ export class DappRadarService {
 
     private getCacheKey(network: NetworkType): string {
         return `${network}_dapps`;
+    }
+
+    private ThrowIfNetworkNotSupported(network: NetworkType): void {
+        if(network !== 'astar' && network !== 'shiden') {
+            throw new Error(`Network ${network} is not supported.`);
+        }
     }
 }

--- a/src/services/DappRadarService.ts
+++ b/src/services/DappRadarService.ts
@@ -234,7 +234,7 @@ export class DappRadarService {
     }
 
     private ThrowIfNetworkNotSupported(network: NetworkType): void {
-        if(network !== 'astar' && network !== 'shiden') {
+        if (network !== 'astar' && network !== 'shiden') {
             throw new Error(`Network ${network} is not supported.`);
         }
     }

--- a/tests/services/DappRadarService.test.ts
+++ b/tests/services/DappRadarService.test.ts
@@ -6,7 +6,7 @@ import { NetworkType } from '../../src/networks';
 describe('DappRadarService methods parameters check', () => {
     let dappRadarService: IDappRadarService;
     const emptyNetwork = '' as NetworkType;
-    const invalidNetwork = 'dsa' as NetworkType;
+    const invalidNetwork = 'astar1' as NetworkType;
 
     beforeEach(() => {
         dappRadarService = new DappRadarService(new FirebaseServiceMock());

--- a/tests/services/DappRadarService.test.ts
+++ b/tests/services/DappRadarService.test.ts
@@ -1,0 +1,59 @@
+import 'reflect-metadata';
+import { DappRadarService, IDappRadarService } from '../../src/services/DappRadarService';
+import { FirebaseServiceMock } from './FirebaseServiceMock';
+import { NetworkType } from '../../src/networks';
+
+describe('DappRadarService methods parameters check', () => {
+    let dappRadarService: IDappRadarService;
+    const emptyNetwork = '' as NetworkType;
+    const invalidNetwork = 'dsa' as NetworkType;
+
+    beforeEach(() => {
+        dappRadarService = new DappRadarService(new FirebaseServiceMock());
+    });
+
+    it('getDapps checks parameters', async () => {
+        await expect(dappRadarService.getDapps(invalidNetwork)).rejects.toThrowError(
+            `Network ${invalidNetwork} is not supported.`,
+        );
+
+        await expect(dappRadarService.getDapps(emptyNetwork)).rejects.toThrowError('network');
+    });
+
+    it('getAggregatedData checks parameters', async () => {
+        await expect(dappRadarService.getAggregatedData(invalidNetwork, '7d')).rejects.toThrowError(
+            `Network ${invalidNetwork} is not supported.`,
+        );
+
+        await expect(dappRadarService.getAggregatedData(emptyNetwork, '7d')).rejects.toThrowError('network');
+        await expect(dappRadarService.getAggregatedData('astar', '')).rejects.toThrowError('period');
+    });
+
+    it('getDappTransactionsHistory checks parameters', async () => {
+        await expect(
+            dappRadarService.getDappTransactionsHistory('Test', 'http:://test.com', invalidNetwork),
+        ).rejects.toThrowError(`Network ${invalidNetwork} is not supported.`);
+
+        await expect(
+            dappRadarService.getDappTransactionsHistory('Test', 'http:://test.com', emptyNetwork),
+        ).rejects.toThrowError('network');
+        await expect(dappRadarService.getDappTransactionsHistory('', 'http://test.com', 'astar')).rejects.toThrowError(
+            'dappName',
+        );
+        await expect(dappRadarService.getDappTransactionsHistory('Test', '', 'astar')).rejects.toThrowError('dappUrl');
+    });
+
+    it('getDappUawHistory checks parameters', async () => {
+        await expect(
+            dappRadarService.getDappUawHistory('Test', 'http:://test.com', invalidNetwork),
+        ).rejects.toThrowError(`Network ${invalidNetwork} is not supported.`);
+
+        await expect(dappRadarService.getDappUawHistory('Test', 'http:://test.com', emptyNetwork)).rejects.toThrowError(
+            'network',
+        );
+        await expect(dappRadarService.getDappUawHistory('', 'http://test.com', 'astar')).rejects.toThrowError(
+            'dappName',
+        );
+        await expect(dappRadarService.getDappUawHistory('Test', '', 'astar')).rejects.toThrowError('dappUrl');
+    });
+});


### PR DESCRIPTION
Added additional network value check for all public DappRadarService method. Since Dapp Radar supports Astar and Shiden only, it doesn't make sense to accept other values.
Added unit tests for parameters check