### PR TITLE
Additional endpoint to return simple dapps list

### DIFF
--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -137,7 +137,21 @@ export class DappsStakingController extends ControllerBase implements IControlle
 
         app.route('/api/v1/:network/dapps-staking/dapps').get(async (req: Request, res: Response) => {
             /*
-                #swagger.description = 'Retrieves list of dapps registered for dapps staking'
+                #swagger.description = 'Retrieves list of dapps (full model) registered for dapps staking'
+                #swagger.tags = ['Dapps Staking']
+                #swagger.parameters['network'] = {
+                    in: 'path',
+                    description: 'The network name. Supported networks: astar, shiden, shibuya, rocstar, development',
+                    required: true,
+                    enum: ['astar', 'shiden', 'shibuya', 'rocstar']
+                }
+            */
+            res.json(await this._firebaseService.getDappsFull(req.params.network as NetworkType));
+        });
+
+        app.route('/api/v1/:network/dapps-staking/dappssimple').get(async (req: Request, res: Response) => {
+            /*
+                #swagger.description = 'Retrieves list of dapps (basic info) registered for dapps staking'
                 #swagger.tags = ['Dapps Staking']
                 #swagger.parameters['network'] = {
                     in: 'path',

--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -42,7 +42,7 @@ export class FirebaseService implements IFirebaseService {
         this.initApp();
 
         const collectionKey = await this.getCollectionKey(network);
-        const query = admin.firestore().collection(collectionKey).select('name', 'iconUrl', 'address', 'categories');
+        const query = admin.firestore().collection(collectionKey).select('name', 'iconUrl', 'address', 'mainCategory');
 
         return this.getDappsData(query);
     }

--- a/tests/services/FirebaseServiceMock.ts
+++ b/tests/services/FirebaseServiceMock.ts
@@ -7,6 +7,10 @@ export class FirebaseServiceMock implements IFirebaseService {
         return [];
     }
 
+    public async getDappsFull(network: NetworkType): Promise<DappItem[]> {
+        return [];
+    }
+
     public async registerDapp(dapp: NewDappItem, network: NetworkType): Promise<DappItem> {
         throw new Error('Method not implemented.');
     }


### PR DESCRIPTION
Created additional endpoint `/api/v1/:network/dapps-staking/dappssimple` to provide simplified list of daps with just mandatory properties. This optiomization will improve the portal performance and resolve problems with Token API handling large volume of data.