### PR TITLE
NFT controller and service

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -40,6 +40,8 @@ import {
     WithdrawFromUnbondedParser,
     WithdrawParser,
 } from './services/GiantSquid';
+import { BluezNftService, INftService } from './services/NftService';
+import { NftController } from './controllers/NftController';
 
 const container = new Container();
 
@@ -115,6 +117,7 @@ container
     .inRequestScope();
 container.bind<IDappRadarService>(ContainerTypes.DappRadarService).to(DappRadarService).inRequestScope();
 container.bind<IGiantSquidService>(ContainerTypes.GiantSquidService).to(GiantSquidService).inRequestScope();
+container.bind<INftService>(ContainerTypes.BluezNftService).to(BluezNftService).inRequestScope();
 
 // Giant squid parsers
 container.bind<ICallParser>(CallNameMapping.bond_and_stake).to(BondAndStakeParser).inSingletonScope();
@@ -133,5 +136,6 @@ container.bind<IControllerBase>(ContainerTypes.Controller).to(DappsStakingContro
 container.bind<IControllerBase>(ContainerTypes.Controller).to(NodeController);
 container.bind<IControllerBase>(ContainerTypes.Controller).to(TxQueryController);
 container.bind<IControllerBase>(ContainerTypes.Controller).to(MonthlyActiveWalletsController);
+container.bind<IControllerBase>(ContainerTypes.Controller).to(NftController);
 
 export default container;

--- a/src/containertypes.ts
+++ b/src/containertypes.ts
@@ -14,4 +14,5 @@ export const ContainerTypes = {
     DappsStakingStatsService: 'DappsStakingStatsService',
     DappRadarService: 'DappRadarService',
     GiantSquidService: 'GiantSquidService',
+    BluezNftService: 'BluezNftService',
 };

--- a/src/controllers/NftController.ts
+++ b/src/controllers/NftController.ts
@@ -1,0 +1,41 @@
+import express, { Request, Response } from 'express';
+import { inject, injectable } from 'inversify';
+import { ControllerBase } from './ControllerBase';
+import { IControllerBase } from './IControllerBase';
+import { ContainerTypes } from '../containertypes';
+import { INftService } from '../services/NftService';
+import { NetworkType } from '../networks';
+
+@injectable()
+export class NftController extends ControllerBase implements IControllerBase {
+    constructor(@inject(ContainerTypes.BluezNftService) private nftService: INftService) {
+        super();
+    }
+
+    public register(app: express.Application): void {
+        app.route('/api/v1/:network/nft/owned/:owner').get(async (req: Request, res: Response) => {
+            try {
+                const network = req.params.network as NetworkType;
+                const owner = req.params.owner;
+                const currentPage = req.query.page as string;
+                const pageSize = req.query.pageSize as string;
+                res.json(await this.nftService.getOwnedTokens(network, owner, currentPage, pageSize));
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
+        });
+
+        app.route('/api/v1/:network/nft/metadata/:contractAddress/:tokenId').get(
+            async (req: Request, res: Response) => {
+                try {
+                    const network = req.params.network as NetworkType;
+                    const contractAddress = req.params.contractAddress;
+                    const tokenId = req.params.tokenId;
+                    res.json(await this.nftService.getNftMetadata(network, contractAddress, tokenId));
+                } catch (err) {
+                    this.handleError(res, err as Error);
+                }
+            },
+        );
+    }
+}

--- a/src/models/Nft.ts
+++ b/src/models/Nft.ts
@@ -1,17 +1,17 @@
 export interface NftMetadata {
-  name: string;
-  description: string;
-  image: string;
-  contractAddress: string;
-  tokenId: string;
-  tokenUri: string;
-  ownerAddress: string;
+    name: string;
+    description: string;
+    image: string;
+    contractAddress: string;
+    tokenId: string;
+    tokenUri: string;
+    ownerAddress: string;
 }
 
 export interface NftResponse {
-  items: NftMetadata[];
-  total: number;
-  page: number;
-  size: number;
-  pages: number;
+    items: NftMetadata[];
+    total: number;
+    page: number;
+    size: number;
+    pages: number;
 }

--- a/src/models/Nft.ts
+++ b/src/models/Nft.ts
@@ -1,0 +1,17 @@
+export interface NftMetadata {
+  name: string;
+  description: string;
+  image: string;
+  contractAddress: string;
+  tokenId: string;
+  tokenUri: string;
+  ownerAddress: string;
+}
+
+export interface NftResponse {
+  items: NftMetadata[];
+  total: number;
+  page: number;
+  size: number;
+  pages: number;
+}

--- a/src/services/NftService.ts
+++ b/src/services/NftService.ts
@@ -1,0 +1,74 @@
+import { injectable } from 'inversify';
+import { NftMetadata, NftResponse } from '../models/Nft';
+import axios from 'axios';
+import * as functions from 'firebase-functions';
+import { NetworkType } from '../networks';
+import { Guard } from '../guard';
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_PAGE = 1;
+
+export interface INftService {
+    getOwnedTokens(
+        network: NetworkType,
+        ownerAddress: string,
+        currentPage?: string,
+        pageSize?: string,
+    ): Promise<NftResponse[]>;
+    getNftMetadata(network: NetworkType, contractAddress: string, tokenId: string): Promise<NftMetadata | undefined>;
+}
+
+@injectable()
+export class BluezNftService implements INftService {
+    public async getOwnedTokens(
+        network: NetworkType,
+        ownerAddress: string,
+        currentPage?: string,
+        pageSize?: string,
+    ): Promise<NftResponse[]> {
+        this.throwIfNetworkIsNotSupported(network);
+        Guard.ThrowIfUndefined(ownerAddress, 'ownerAddress');
+
+        const ownedTokensUrl = `${this.getBaseUri(network)}/getNFTsForOwner?owner=${ownerAddress}&pageKey=${
+            currentPage ?? DEFAULT_PAGE
+        }&pageSize=${pageSize ?? DEFAULT_PAGE_SIZE}`;
+        const result = await axios.get(ownedTokensUrl);
+
+        return result.data;
+    }
+
+    public async getNftMetadata(
+        network: NetworkType,
+        contractAddress: string,
+        tokenId: string,
+    ): Promise<NftMetadata | undefined> {
+        this.throwIfNetworkIsNotSupported(network);
+        Guard.ThrowIfUndefined(contractAddress, 'contractAddress');
+        Guard.ThrowIfUndefined(tokenId, 'tokenId');
+
+        const metadataUri = `${this.getBaseUri(
+            network,
+        )}/getNFTMetadata?contractAddress=${contractAddress}&tokenId=${tokenId}`;
+        const result = await axios.get(metadataUri);
+
+        return result.data ?? undefined;
+    }
+
+    private throwIfNetworkIsNotSupported(network: NetworkType): void {
+        if (network !== 'astar' && network !== 'shibuya') {
+            throw new Error(`Network ${network} is not supported.`);
+        }
+    }
+
+    private getBaseUri(network: NetworkType): string {
+        switch (network) {
+            case 'astar':
+                return `https://api.bluez.app/api/nft/v3/${String(functions.config().bluez.apikeyastar)}`;
+            case 'shibuya':
+                return `https://apidev.bluez.app/api/nft/v3/${String(functions.config().bluez.apikeyshibuya)}`;
+            default:
+                // Bluez doesn't support shiden ATM.
+                throw new Error(`Network ${network} is not supported.`);
+        }
+    }
+}


### PR DESCRIPTION
The new NFT controller returns NFTs metadata. At the moment Bluez API is supported, but this can be easily changed in the future by creating a new NFT service to fetch NFT metadata from some other provider.

There are two endpoints:
First one to return all NFTs owned by an user address
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v1/astar/nft/owned/0xa82bcEb98540Eb39912753D86F3d76843fb8B736?page=1&pageSize=100

Second one to return token metadata for a given contract address and token id
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v1/astar/nft/metadata/0x7b2152e51130439374672af463b735a59a47ea85/1


