### PR TITLE
Nomination transfer event parser fix

### DIFF
--- a/src/services/GiantSquid/CallParser.ts
+++ b/src/services/GiantSquid/CallParser.ts
@@ -45,8 +45,8 @@ export class UnbondAndUnstakeParser extends CallParser implements ICallParser {
 export class NominationTransferParser extends CallParser implements ICallParser {
     public parse(call: DappStakingCallData): UserEvent {
         const result = super.parse(call);
-        result.contractAddress = call.argsStr[3];
-        result.amount = call.argsStr[4];
+        result.contractAddress = call.argsStr[2];
+        result.amount = call.argsStr[3];
 
         return result;
     }


### PR DESCRIPTION
Fix for error in NominationTransfer event parser where amount was incorrectly parsed