### PR TITLE
Return a dApp creation time

### DIFF
--- a/src/models/Dapp.ts
+++ b/src/models/Dapp.ts
@@ -18,6 +18,7 @@ export interface DappItem {
     communities: Community[];
     contractType: string;
     mainCategory: Category;
+    creationTime: number;
 }
 
 export interface NewDappItem extends DappItem {

--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -42,7 +42,10 @@ export class FirebaseService implements IFirebaseService {
         this.initApp();
 
         const collectionKey = await this.getCollectionKey(network);
-        const query = admin.firestore().collection(collectionKey).select('name', 'iconUrl', 'address', 'mainCategory');
+        const query = admin
+            .firestore()
+            .collection(collectionKey)
+            .select('name', 'iconUrl', 'address', 'mainCategory', 'imagesUrl');
 
         return this.getDappsData(query);
     }
@@ -221,6 +224,7 @@ export class FirebaseService implements IFirebaseService {
         const result: DappItem[] = [];
         data.forEach((x) => {
             const data = x.data() as DappItem;
+            data.creationTime = x.createTime.seconds;
             result.push(data);
         });
 


### PR DESCRIPTION
Extended result set from 
`api/v1/astar/dapps-staking/dappssimple`
to return a dApp creation date and urls of the dApp images, since this will be needed for the portal auto cards feature

To test locally use
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v1/astar/dapps-staking/dappssimple