### PR TITLE
Sending base64 images optimization

### DIFF
--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -183,7 +183,11 @@ export class DappsStakingController extends ControllerBase implements IControlle
             */
 
             try {
-                const data = await this._firebaseService.getDapp(req.params.address, req.params.network as NetworkType);
+                const data = await this._firebaseService.getDapp(
+                    req.params.address,
+                    req.params.network as NetworkType,
+                    req.query.forEdit as unknown as boolean,
+                );
 
                 if (data) {
                     res.json(data);

--- a/src/controllers/DappsStakingController.ts
+++ b/src/controllers/DappsStakingController.ts
@@ -186,7 +186,7 @@ export class DappsStakingController extends ControllerBase implements IControlle
                 const data = await this._firebaseService.getDapp(
                     req.params.address,
                     req.params.network as NetworkType,
-                    req.query.forEdit as unknown as boolean,
+                    req.query.forEdit?.toString()?.toLowerCase() === 'true',
                 );
 
                 if (data) {

--- a/tests/services/FirebaseServiceMock.ts
+++ b/tests/services/FirebaseServiceMock.ts
@@ -15,7 +15,7 @@ export class FirebaseServiceMock implements IFirebaseService {
         throw new Error('Method not implemented.');
     }
 
-    public async getDapp(address: string, network: NetworkType): Promise<NewDappItem | undefined> {
+    public async getDapp(address: string, network: NetworkType, forEdit = false): Promise<NewDappItem | undefined> {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
During a dApp fetching from Firebase images were base64 encoded and send with response. Encoded images are only needed for the dApp editing so I make a query param so in request you can choose if you need encoded images or not. By default dApp data without encoded images will be send.