### PR TITLE
rewardAmount Constant renamed

### DIFF
--- a/src/client/AstarApi2.ts
+++ b/src/client/AstarApi2.ts
@@ -16,7 +16,7 @@ export class AstarApi2 extends BaseApi implements IAstarApi {
     public async getAprCalculationData(): Promise<AprCalculationData> {
         await this.ensureConnection();
         const results = await Promise.all([
-            this._api.consts.blockReward.rewardAmount,
+            this._api.consts.blockReward.maxBlockRewardAmount,
             this._api.query.timestamp.now(),
             this._api.rpc.chain.getHeader(),
             this._api.query.blockReward.rewardDistributionConfigStorage<RewardDistributionConfig>(),

--- a/src/client/BaseApi.ts
+++ b/src/client/BaseApi.ts
@@ -70,7 +70,7 @@ export class BaseApi implements IAstarApi {
     public async getAprCalculationData(): Promise<AprCalculationData> {
         await this.ensureConnection();
         const results = await Promise.all([
-            this._api.consts.blockReward.rewardAmount,
+            this._api.consts.blockReward.maxBlockRewardAmount,
             this._api.query.timestamp.now(),
             this._api.rpc.chain.getHeader(),
             this._api.consts.dappsStaking.developerRewardPercentage.toHuman(),


### PR DESCRIPTION
`rewardAmount` was renamed in runtime to `maxBlockRewardAmount`