### PR TITLE
Token price cache

### DIFF
--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -1,0 +1,43 @@
+import { Guard } from '../guard';
+
+export interface CacheItem<T> {
+    updatedAt: number;
+    data: T;
+}
+
+export class CacheService<T> {
+    private cache = new Map<string, CacheItem<T>>();
+
+    constructor(private cachedItemValidityTimeMs: number = 60000) {}
+
+    public getItem(key: string): T | undefined {
+        Guard.ThrowIfUndefined('key', key);
+
+        const cacheItem = this.cache.get(key);
+
+        if (!cacheItem) {
+            return undefined;
+        }
+
+        if (this.isExpired(cacheItem)) {
+            this.cache.delete(key);
+            return undefined;
+        }
+
+        return cacheItem.data;
+    }
+
+    public setItem(key: string, item: T): void {
+        Guard.ThrowIfUndefined('key', key);
+        Guard.ThrowIfUndefined('item', item);
+
+        this.cache.set(key, {
+            data: item,
+            updatedAt: Date.now(),
+        });
+    }
+
+    private isExpired(cacheItem: CacheItem<T>): boolean {
+        return cacheItem.updatedAt + this.cachedItemValidityTimeMs < Date.now();
+    }
+}

--- a/src/services/CoinGeckoPriceProvider.ts
+++ b/src/services/CoinGeckoPriceProvider.ts
@@ -11,17 +11,15 @@ type CoinGeckoTokenInfo = { id: string; symbol: string; name: string };
 
 @injectable()
 export class CoinGeckoPriceProvider implements IPriceProvider {
-    public static BaseUrl = 'https://pro-api.coingecko.com/api/v3';
+    public static BaseUrl = 'https://api.coingecko.com/api/v3';
     private static tokens: CoinGeckoTokenInfo[];
-
-    constructor(@inject(ContainerTypes.FirebaseService) private firebaseService: IFirebaseService) {}
 
     public async getUsdPrice(symbol: string): Promise<number> {
         const tokenSymbol = await this.getTokenId(symbol);
 
         if (tokenSymbol) {
             const url = `${CoinGeckoPriceProvider.BaseUrl}/simple/price?ids=${tokenSymbol}&vs_currencies=usd`;
-            const result = await axios.get(url, this.getOptions());
+            const result = await axios.get(url);
 
             if (result.data[tokenSymbol]) {
                 const price = result.data[tokenSymbol].usd;
@@ -43,18 +41,8 @@ export class CoinGeckoPriceProvider implements IPriceProvider {
 
     private async getTokenList(): Promise<CoinGeckoTokenInfo[]> {
         const url = `${CoinGeckoPriceProvider.BaseUrl}/coins/list`;
-        const result = await axios.get<CoinGeckoTokenInfo[]>(url, this.getOptions());
+        const result = await axios.get<CoinGeckoTokenInfo[]>(url);
 
         return result.data;
-    }
-
-    public getOptions(): AxiosRequestConfig {
-        const apiKey = this.firebaseService.getEnvVariable('coingecko', 'apikey');
-        const options: AxiosRequestConfig = {};
-        if (apiKey) {
-            options.headers = { 'x-cg-pro-api-key': apiKey };
-        }
-
-        return options;
     }
 }

--- a/src/services/StatsIndexerService.ts
+++ b/src/services/StatsIndexerService.ts
@@ -6,7 +6,6 @@ import { ContainerTypes } from '../containertypes';
 import { NetworkType } from '../networks';
 import { getDateUTC, getDateYyyyMmDd, getSubscanUrl, getSubscanOption } from '../utils';
 import { Pair, PeriodType, ServiceBase } from './ServiceBase';
-import { CoinGeckoPriceProvider } from './CoinGeckoPriceProvider';
 
 export interface IStatsIndexerService {
     getDappStakingTvl(network: NetworkType, period: PeriodType): Promise<Pair[]>;
@@ -32,10 +31,7 @@ const API_URLS_TVL = {
  * Fetches statistics from external data source
  */
 export class StatsIndexerService extends ServiceBase implements IStatsIndexerService {
-    constructor(
-        @inject(ContainerTypes.ApiFactory) private _apiFactory: IApiFactory,
-        @inject(ContainerTypes.PriceProvider) private _priceProvider: CoinGeckoPriceProvider,
-    ) {
+    constructor(@inject(ContainerTypes.ApiFactory) private _apiFactory: IApiFactory) {
         super();
     }
 
@@ -146,8 +142,7 @@ export class StatsIndexerService extends ServiceBase implements IStatsIndexerSer
         try {
             const interval = 'daily';
             const result = await axios.get(
-                `https://pro-api.coingecko.com/api/v3/coins/${network}/market_chart?vs_currency=usd&days=${numberOfDays}&interval=${interval}`,
-                this._priceProvider.getOptions(),
+                `https://api.coingecko.com/api/v3/coins/${network}/market_chart?vs_currency=usd&days=${numberOfDays}&interval=${interval}`,
             );
             return result.data.prices;
         } catch (e) {


### PR DESCRIPTION
Cache token prices for a short time, so we don't need to fetch them on every request

Test URL: 
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v1/token/price/astr
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v1/token/price/btc
or any other token
