### PR TITLE
Freeze firebase-action to v13.0.3

### DIFF
--- a/.github/workflows/firebase-merge.yml
+++ b/.github/workflows/firebase-merge.yml
@@ -21,7 +21,7 @@ jobs:
           channelId: live
           projectId: astar-token-api
       - name: Deploy Firebase Function
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v13.0.3
         with:
           args: deploy --only functions --debug
         env:


### PR DESCRIPTION
Freeze firebase-action to v13.0.3

In relation to https://github.com/w9jds/firebase-action/issues/217