### PR TITLE
fix: set memory allocation to 2BG

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,5 +20,5 @@ app.use(cors());
 const controllers: IControllerBase[] = container.getAll<IControllerBase>(ContainerTypes.Controller);
 controllers.forEach((controller) => controller.register(app));
 
-functions.runWith({ memory: '512MB' });
+functions.runWith({ memory: '2GB' });
 exports.app = functions.https.onRequest(app);


### PR DESCRIPTION
Reported as a fix here: https://github.com/firebase/firebase-functions/issues/1346#issuecomment-1544267076