### PR TITLE
fix: Check if description exists first

### DIFF
--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -238,7 +238,9 @@ export class FirebaseService implements IFirebaseService {
         data.forEach((x) => {
             const data = x.data() as DappItem;
             data.creationTime = x.createTime.seconds;
-            data.description = this.decode(data.description);
+            if (data.description) {
+                data.description = this.decode(data.description);
+            }
             data.shortDescription = this.decode(data.shortDescription ?? '');
             result.push(data);
         });


### PR DESCRIPTION
check if description exists first

Both dapps endpoint rely on this.getDappsData but only one needs description.


```
dapps-staking/dapps          --> this._firebaseService.getDappsFull --> this.getDappsData
dapps-staking/dappssimple    --> this._firebaseService.getDapps     --> this.getDappsData
dapps-staking/dapps/:address --> this._firebaseService.getDapp
```