### PR TITLE
feat: Adds lockers count to the tvl endpoint

### DIFF
--- a/public/swagger.json
+++ b/public/swagger.json
@@ -627,7 +627,130 @@
         "tags": [
           "Dapps Staking"
         ],
-        "description": "Retrieves dapps staking TVL and total number of unique lockers for a given network and period.",
+        "description": "Retrieves dapps staking TVL for a given network and period.",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya"
+            ]
+          },
+          {
+            "name": "period",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The period type. Supported values: 1 day, 7 days, 30 days, 90 days, 1 year",
+            "enum": [
+              "1 day",
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/{network}/dapps-staking/stakers-total/{period}": {
+      "get": {
+        "tags": [
+          "Dapps Staking"
+        ],
+        "description": "Retrieves dapps staking Total Value Staked and Total Number of Unique Stakers for a given network and period.",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya"
+            ]
+          },
+          {
+            "name": "period",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The period type. Supported values: 1 day, 7 days, 30 days, 90 days, 1 year",
+            "enum": [
+              "1 day",
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/{network}/dapps-staking/lockers-total/{period}": {
+      "get": {
+        "tags": [
+          "Dapps Staking"
+        ],
+        "description": "Retrieves dapps staking Total Value Locked and Total Number of Unique Lockers for a given network and period.",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya"
+            ]
+          },
+          {
+            "name": "period",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The period type. Supported values: 1 day, 7 days, 30 days, 90 days, 1 year",
+            "enum": [
+              "1 day",
+              "7 days",
+              "30 days",
+              "90 days",
+              "1 year"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/{network}/dapps-staking/lockers-and-stakers-total/{period}": {
+      "get": {
+        "tags": [
+          "Dapps Staking"
+        ],
+        "description": "Retrieves dapps staking Total Value Locked & Staked and Total Number of Unique Lockers & Stakers for a given network and period.",
         "parameters": [
           {
             "name": "network",

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -627,7 +627,7 @@
         "tags": [
           "Dapps Staking"
         ],
-        "description": "Retrieves dapps staking TVL for a given network and period.",
+        "description": "Retrieves dapps staking TVL and total number of unique lockers for a given network and period.",
         "parameters": [
           {
             "name": "network",
@@ -987,7 +987,14 @@
           {
             "name": "transaction",
             "in": "query",
-            "type": "string"
+            "description": "The Reward Event transaction type. Supported values: Reward, BonusReward, DAppReward",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "Reward",
+              "BonusReward",
+              "DAppReward"
+            ]
           }
         ],
         "responses": {

--- a/src/controllers/DappsStakingV3Controller.ts
+++ b/src/controllers/DappsStakingV3Controller.ts
@@ -19,7 +19,7 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
          */
         app.route('/api/v3/:network/dapps-staking/tvl/:period').get(async (req: Request, res: Response) => {
             /*
-                        #swagger.description = 'Retrieves dapps staking TVL and total number of unique lockers for a given network and period.'
+                        #swagger.description = 'Retrieves dapps staking TVL for a given network and period.'
                         #swagger.tags = ['Dapps Staking']
                         #swagger.parameters['network'] = {
                             in: 'path',
@@ -41,6 +41,83 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
                 ),
             );
         });
+
+        app.route('/api/v3/:network/dapps-staking/stakers-total/:period').get(async (req: Request, res: Response) => {
+            /*
+                        #swagger.description = 'Retrieves dapps staking Total Value Staked and Total Number of Unique Stakers for a given network and period.'
+                        #swagger.tags = ['Dapps Staking']
+                        #swagger.parameters['network'] = {
+                            in: 'path',
+                            description: 'The network name. Supported networks: astar',
+                            required: true,
+                            enum: ['astar', 'shiden', 'shibuya']
+                        }
+                        #swagger.parameters['period'] = {
+                            in: 'path',
+                            description: 'The period type. Supported values: 1 day, 7 days, 30 days, 90 days, 1 year',
+                            required: true,
+                            enum: ['1 day', '7 days', '30 days', '90 days', '1 year']
+                        }
+                    */
+            res.json(
+                await this._dappsStakingEvents.getDappStakingStakersTotal(
+                    req.params.network as NetworkType,
+                    req.params.period as PeriodType,
+                ),
+            );
+        });
+
+        app.route('/api/v3/:network/dapps-staking/lockers-total/:period').get(async (req: Request, res: Response) => {
+            /*
+                        #swagger.description = 'Retrieves dapps staking Total Value Locked and Total Number of Unique Lockers for a given network and period.'
+                        #swagger.tags = ['Dapps Staking']
+                        #swagger.parameters['network'] = {
+                            in: 'path',
+                            description: 'The network name. Supported networks: astar',
+                            required: true,
+                            enum: ['astar', 'shiden', 'shibuya']
+                        }
+                        #swagger.parameters['period'] = {
+                            in: 'path',
+                            description: 'The period type. Supported values: 1 day, 7 days, 30 days, 90 days, 1 year',
+                            required: true,
+                            enum: ['1 day', '7 days', '30 days', '90 days', '1 year']
+                        }
+                    */
+            res.json(
+                await this._dappsStakingEvents.getDappStakingLockersTotal(
+                    req.params.network as NetworkType,
+                    req.params.period as PeriodType,
+                ),
+            );
+        });
+
+        app.route('/api/v3/:network/dapps-staking/lockers-and-stakers-total/:period').get(
+            async (req: Request, res: Response) => {
+                /*
+                        #swagger.description = 'Retrieves dapps staking Total Value Locked & Staked and Total Number of Unique Lockers & Stakers for a given network and period.'
+                        #swagger.tags = ['Dapps Staking']
+                        #swagger.parameters['network'] = {
+                            in: 'path',
+                            description: 'The network name. Supported networks: astar',
+                            required: true,
+                            enum: ['astar', 'shiden', 'shibuya']
+                        }
+                        #swagger.parameters['period'] = {
+                            in: 'path',
+                            description: 'The period type. Supported values: 1 day, 7 days, 30 days, 90 days, 1 year',
+                            required: true,
+                            enum: ['1 day', '7 days', '30 days', '90 days', '1 year']
+                        }
+                    */
+                res.json(
+                    await this._dappsStakingEvents.getDappStakingLockersAndStakersTotal(
+                        req.params.network as NetworkType,
+                        req.params.period as PeriodType,
+                    ),
+                );
+            },
+        );
 
         app.route('/api/v3/:network/dapps-staking/stakerscount/:contractAddress/:period').get(
             async (req: Request, res: Response) => {

--- a/src/controllers/DappsStakingV3Controller.ts
+++ b/src/controllers/DappsStakingV3Controller.ts
@@ -19,7 +19,7 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
          */
         app.route('/api/v3/:network/dapps-staking/tvl/:period').get(async (req: Request, res: Response) => {
             /*
-                        #swagger.description = 'Retrieves dapps staking TVL for a given network and period.'
+                        #swagger.description = 'Retrieves dapps staking TVL and total number of unique lockers for a given network and period.'
                         #swagger.tags = ['Dapps Staking']
                         #swagger.parameters['network'] = {
                             in: 'path',
@@ -284,7 +284,7 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
                     }
                     #swagger.parameters['transaction'] = {
                         in: 'query',
-                        description: 'The Reward Event transaction type. Supported values: Reward', 'BonusReward', 'DAppReward',
+                        description: 'The Reward Event transaction type. Supported values: Reward, BonusReward, DAppReward',
                         required: false,
                         type: 'string',
                         enum: ['Reward', 'BonusReward', 'DAppReward']

--- a/src/services/DappsStakingEvents.ts
+++ b/src/services/DappsStakingEvents.ts
@@ -156,13 +156,16 @@ export class DappsStakingEvents extends ServiceBase implements IDappsStakingEven
                     ) {
                       id
                       tvl
+                      lockersCount
                     }
                   }`,
             });
 
-            const indexedTvl = result.data.data.tvlAggregatedDailies.map((node: { id: string; tvl: number }) => {
-                return [node.id, node.tvl];
-            });
+            const indexedTvl = result.data.data.tvlAggregatedDailies.map(
+                (node: { id: string; tvl: number; lockersCount: number }) => {
+                    return [node.id, node.tvl, node.lockersCount];
+                },
+            );
 
             return indexedTvl;
         } catch (e) {

--- a/src/services/ServiceBase.ts
+++ b/src/services/ServiceBase.ts
@@ -3,8 +3,16 @@ import { injectable } from 'inversify';
 export type PeriodType = '1 day' | '7 days' | '30 days' | '90 days' | '1 year';
 export type PeriodTypeEra = '7 eras' | '30 eras' | '90 eras' | 'all';
 export type Pair = { date: number; value: number };
+export type Triplet = { date: string; count: number; amount: number };
 export type List = { stakerAddress: string; amount: bigint };
 export type DateRange = { start: Date; end: Date };
+export type TotalAmountCount = {
+    date: string;
+    tvl: number | undefined;
+    lockersCount: number | undefined;
+    tvs: number | undefined;
+    stakersCount: number | undefined;
+};
 
 const DEFAULT_RANGE_LENGTH_DAYS = 7;
 


### PR DESCRIPTION
**Prerequisite:** graphql indexes have to be on v2 first 

Add 3 new enpoints with 3 values each for stakers and lockers. (date, count, amount)
and a combined endpoint.

`http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v3/shiden/dapps-staking/stakers-total/90%20days`

```json
[
  {
    "date": "1708041600000",
    "count": 403,
    "amount": "1977589088000000000000000"
  },
  {
    "date": "1707955200000",
    "count": 397,
    "amount": "1967662208000000000000000"
  }, ...
```


`http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v3/shiden/dapps-staking/lockers-total/90%20days`

```json
[
  {
    "date": "1708041600000",
    "count": 3343,
    "amount": "16286708604872965460014209"
  },
  {
    "date": "1707955200000",
    "count": 3344,
    "amount": "16286474924238392891442274"
  }, ...
```


`http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v3/shiden/dapps-staking/lockers-and-stakers-total/90%20days`

```json
[
  {
    "date": "1708041600000",
    "tvl": "16286708604872965460014209",
    "lockersCount": 3343,
    "tvs": "1977589088000000000000000",
    "stakersCount": 403
  },
  {
    "date": "1707955200000",
    "tvl": "16286474924238392891442274",
    "lockersCount": 3344,
    "tvs": "1967662208000000000000000",
    "stakersCount": 397
  }, ...
```
  