### PR TITLE
add USD price to v3 totals endpoints

### DIFF
--- a/src/services/ServiceBase.ts
+++ b/src/services/ServiceBase.ts
@@ -3,7 +3,7 @@ import { injectable } from 'inversify';
 export type PeriodType = '1 day' | '7 days' | '30 days' | '90 days' | '1 year';
 export type PeriodTypeEra = '7 eras' | '30 eras' | '90 eras' | 'all';
 export type Pair = { date: number; value: number };
-export type Triplet = { date: string; count: number; amount: number };
+export type Quartet = { date: string; count: number; amount: number; price: number };
 export type List = { stakerAddress: string; amount: bigint };
 export type DateRange = { start: Date; end: Date };
 export type TotalAmountCount = {
@@ -12,6 +12,7 @@ export type TotalAmountCount = {
     lockersCount: number | undefined;
     tvs: number | undefined;
     stakersCount: number | undefined;
+    usdPrice: number | undefined;
 };
 
 const DEFAULT_RANGE_LENGTH_DAYS = 7;


### PR DESCRIPTION
add USD price to v3 totals endpoints

**Do not merge**

`http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v3/shiden/dapps-staking/lockers-and-stakers-total/90%20days`

```
[
  {
    "date": "1709596800000",
    "tvl": "16579101402054643548270519",
    "lockersCount": 3287,
    "tvs": "3443318744000000000000000",
    "stakersCount": 602,
    "usdPrice": 0.341619736343557
  },
  {
    "date": "1709510400000",
    "tvl": "16571721898160896610424001",
    "lockersCount": 3295,
    "tvs": "3428128562000000000000000",
    "stakersCount": 602,
    "usdPrice": 0.357697518843364
  },
  {
    "date": "1709424000000",
    "tvl": "16556173620649056908234398",
    "lockersCount": 3299,
    "tvs": "3271564677000000000000000",
    "stakersCount": 595,
    "usdPrice": 0.355618548450803
  },
]
```