### PR TITLE
Support for getting a token price for a given currency

### DIFF
--- a/src/controllers/TokenStatsController.ts
+++ b/src/controllers/TokenStatsController.ts
@@ -63,7 +63,8 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 }
             */
             try {
-                res.json(await this._priceProvider.getUsdPrice(req.params.symbol));
+                const currency = req.query.currency as string | undefined;
+                res.json(await this._priceProvider.getPrice(req.params.symbol, currency));
             } catch (err) {
                 this.handleError(res, err as Error);
             }

--- a/src/services/CoinGeckoPriceProvider.ts
+++ b/src/services/CoinGeckoPriceProvider.ts
@@ -14,15 +14,15 @@ export class CoinGeckoPriceProvider implements IPriceProvider {
     public static BaseUrl = 'https://api.coingecko.com/api/v3';
     private static tokens: CoinGeckoTokenInfo[];
 
-    public async getUsdPrice(symbol: string): Promise<number> {
+    public async getPrice(symbol: string, currency = 'usd'): Promise<number> {
         const tokenSymbol = await this.getTokenId(symbol);
 
         if (tokenSymbol) {
-            const url = `${CoinGeckoPriceProvider.BaseUrl}/simple/price?ids=${tokenSymbol}&vs_currencies=usd`;
+            const url = `${CoinGeckoPriceProvider.BaseUrl}/simple/price?ids=${tokenSymbol}&vs_currencies=${currency}`;
             const result = await axios.get(url);
 
             if (result.data[tokenSymbol]) {
-                const price = result.data[tokenSymbol].usd;
+                const price = result.data[tokenSymbol][currency];
                 return Number(price);
             }
         }

--- a/src/services/DiaDataPriceProvider.ts
+++ b/src/services/DiaDataPriceProvider.ts
@@ -9,7 +9,7 @@ import { IPriceProvider } from './IPriceProvider';
 export class DiaDataPriceProvider implements IPriceProvider {
     public static BaseUrl = 'https://api.diadata.org/v1/quotation';
 
-    public async getUsdPrice(symbol: string): Promise<number> {
+    public async getPrice(symbol: string): Promise<number> {
         const url = `${DiaDataPriceProvider.BaseUrl}/${symbol}`;
         const result = await axios.get(url);
 

--- a/src/services/IPriceProvider.ts
+++ b/src/services/IPriceProvider.ts
@@ -6,5 +6,5 @@ export interface IPriceProvider {
      * Gets current token price in USD.
      * @param tokenInfo Token information.
      */
-    getUsdPrice(symbol: string): Promise<number>;
+    getPrice(symbol: string, currency: string | undefined): Promise<number>;
 }

--- a/src/services/PriceProviderWithFailover.ts
+++ b/src/services/PriceProviderWithFailover.ts
@@ -18,18 +18,19 @@ export class PriceProviderWithFailover implements IPriceProvider {
      * @param tokenInfo Token information.
      * @returns Token price or 0 if unable to fetch price.
      */
-    public async getUsdPrice(symbol: string): Promise<number> {
+    public async getPrice(symbol: string, currency = 'usd'): Promise<number> {
         Guard.ThrowIfUndefined('symbol', symbol);
 
         const providers = container.getAll<IPriceProvider>(ContainerTypes.PriceProvider);
+        const cacheKey = `${symbol}-${currency}`;
         for (const provider of providers) {
             try {
-                const cacheItem = this.priceCache.getItem(symbol);
+                const cacheItem = this.priceCache.getItem(cacheKey);
                 if (cacheItem) {
                     return cacheItem;
                 } else {
-                    const price = await provider.getUsdPrice(symbol);
-                    this.priceCache.setItem(symbol, price);
+                    const price = await provider.getPrice(symbol, currency);
+                    this.priceCache.setItem(cacheKey, price);
 
                     return price;
                 }


### PR DESCRIPTION
For a time being Token API was able to provide token price in USD only. I added support to provide currency symbol to the endpoint. If currency is not provided the price will be returned in USD. Test endpoint

http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v1/token/price/eth?currency=jpy