### PR TITLE
Created new price endpoint to return price and timestamp

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -44,6 +44,7 @@ import {
 } from './services/GiantSquid';
 import { BluezNftService, INftService } from './services/NftService';
 import { NftController } from './controllers/NftController';
+import { TokenStatsControllerV2 } from './controllers/TokenStatsControllerV2';
 
 const container = new Container();
 
@@ -137,6 +138,7 @@ container.bind<ICallParser>(CallNameMapping.batch).to(BatchCallParser).inSinglet
 
 // controllers registration
 container.bind<IControllerBase>(ContainerTypes.Controller).to(TokenStatsController);
+container.bind<IControllerBase>(ContainerTypes.Controller).to(TokenStatsControllerV2);
 container.bind<IControllerBase>(ContainerTypes.Controller).to(DappsStakingController);
 container.bind<IControllerBase>(ContainerTypes.Controller).to(DappsStakingV3Controller);
 container.bind<IControllerBase>(ContainerTypes.Controller).to(NodeController);

--- a/src/controllers/TokenStatsControllerV2.ts
+++ b/src/controllers/TokenStatsControllerV2.ts
@@ -1,0 +1,43 @@
+import express, { Request, Response } from 'express';
+import { injectable, inject } from 'inversify';
+import { ContainerTypes } from '../containertypes';
+import { IPriceProvider } from '../services/IPriceProvider';
+import { IStatsIndexerService } from '../services/StatsIndexerService';
+import { IStatsService } from '../services/StatsService';
+import { ControllerBase } from './ControllerBase';
+import { IControllerBase } from './IControllerBase';
+
+@injectable()
+export class TokenStatsControllerV2 extends ControllerBase implements IControllerBase {
+    constructor(
+        @inject(ContainerTypes.StatsService) private _statsService: IStatsService,
+        @inject(ContainerTypes.StatsIndexerService) private _indexerService: IStatsIndexerService,
+        @inject(ContainerTypes.PriceProviderWithFailover) private _priceProvider: IPriceProvider,
+    ) {
+        super();
+    }
+
+    public register(app: express.Application): void {
+        /**
+         * @description Token current price route v2.
+         */
+        app.route('/api/v2/token/price/:symbol').get(async (req: Request, res: Response) => {
+            /*
+                #swagger.description = 'Retrieves current token price with timestamp'
+                #swagger.tags = ['Token']
+                #swagger.parameters['symbol'] = {
+                    in: 'path',
+                    description: 'Token symbol (eg. ASTR or SDN)',
+                    required: true,
+                    enum: ['ASTR', 'SDN']
+                }
+            */
+            try {
+                const currency = req.query.currency as string | undefined;
+                res.json(await this._priceProvider.getPriceWithTimestamp(req.params.symbol, currency));
+            } catch (err) {
+                this.handleError(res, err as Error);
+            }
+        });
+    }
+}

--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -10,7 +10,7 @@ export class CacheService<T> {
 
     constructor(private cachedItemValidityTimeMs: number = 60000) {}
 
-    public getItem(key: string): T | undefined {
+    public getItem(key: string): CacheItem<T> | undefined{
         Guard.ThrowIfUndefined('key', key);
 
         const cacheItem = this.cache.get(key);
@@ -19,12 +19,7 @@ export class CacheService<T> {
             return undefined;
         }
 
-        if (this.isExpired(cacheItem)) {
-            this.cache.delete(key);
-            return undefined;
-        }
-
-        return cacheItem.data;
+        return cacheItem;
     }
 
     public setItem(key: string, item: T): void {
@@ -37,7 +32,7 @@ export class CacheService<T> {
         });
     }
 
-    private isExpired(cacheItem: CacheItem<T>): boolean {
+    public isExpired(cacheItem: CacheItem<T>): boolean {
         return cacheItem.updatedAt + this.cachedItemValidityTimeMs < Date.now();
     }
 }

--- a/src/services/CoinGeckoPriceProvider.ts
+++ b/src/services/CoinGeckoPriceProvider.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { inject, injectable } from 'inversify';
-import { IPriceProvider } from './IPriceProvider';
+import { IPriceProvider, TokenInfo } from './IPriceProvider';
 import { ContainerTypes } from '../containertypes';
 import { IFirebaseService } from './FirebaseService';
 
@@ -28,6 +28,15 @@ export class CoinGeckoPriceProvider implements IPriceProvider {
         }
 
         return 0;
+    }
+
+    public async getPriceWithTimestamp(symbol: string, currency: string | undefined): Promise<TokenInfo>{
+        const price = await this.getPrice(symbol, currency);
+
+        return {
+            price,
+            lastUpdated: Date.now(),
+        };
     }
 
     private async getTokenId(symbol: string): Promise<string | undefined> {

--- a/src/services/DiaDataPriceProvider.ts
+++ b/src/services/DiaDataPriceProvider.ts
@@ -19,4 +19,13 @@ export class DiaDataPriceProvider implements IPriceProvider {
 
         return 0;
     }
+
+    public async getPriceWithTimestamp(symbol: string): Promise<{ price: number; lastUpdated: number }> {
+        const price = await this.getPrice(symbol);
+
+        return {
+            price,
+            lastUpdated: Date.now(),
+        };
+    }
 }

--- a/src/services/IPriceProvider.ts
+++ b/src/services/IPriceProvider.ts
@@ -1,3 +1,9 @@
+export type TokenInfo = {
+    price: number;
+    lastUpdated: number;
+}
+
+
 /**
  * Definition of provider for access token price.
  */
@@ -7,4 +13,10 @@ export interface IPriceProvider {
      * @param tokenInfo Token information.
      */
     getPrice(symbol: string, currency: string | undefined): Promise<number>;
+
+    /**
+     * Gets current token price in USD with timestamp.
+     * @param tokenInfo Token price and timestamp.
+     */
+    getPriceWithTimestamp(symbol: string, currency: string | undefined): Promise<TokenInfo>;
 }


### PR DESCRIPTION
Adds new price endpoint to provide a token price with timestamp.
Since all prices are cached, the timestamp returned is a time when price was added to cache

Test url http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v2/token/price/astr