### PR TITLE
null price fix

### DIFF
--- a/src/services/CoinGeckoPriceProvider.ts
+++ b/src/services/CoinGeckoPriceProvider.ts
@@ -23,7 +23,7 @@ export class CoinGeckoPriceProvider implements IPriceProvider {
 
             if (result.data[tokenSymbol]) {
                 const price = result.data[tokenSymbol][currency];
-                return Number(price);
+                return Number(price ?? 0);
             }
         }
 


### PR DESCRIPTION
It can happen that coin gecko returns result, but there is no price for a given currency