### PR TITLE
prevent xss on handleError

### DIFF
--- a/src/controllers/ControllerBase.ts
+++ b/src/controllers/ControllerBase.ts
@@ -5,7 +5,9 @@ import { Response } from 'express';
 export class ControllerBase {
     protected handleError(res: Response, err: Error) {
         const ERROR_STATUS = 500;
-        res.status(ERROR_STATUS).send(err.message);
+        res.status(ERROR_STATUS).json({
+            message: err.message,
+        });
     }
 
     protected handleNotFound(res: Response) {


### PR DESCRIPTION
## Description
Update error response as json to prevent rendering on browser, It can prevent reflected xss attack 

### Changes
Error response will be json, not the text like below

```json
{"message":"Network 1234 is not supported."}
```

