### PR TITLE
Enable period data fetching for Shiden and Astar

### DIFF
--- a/src/services/DappsStakingEvents.ts
+++ b/src/services/DappsStakingEvents.ts
@@ -544,7 +544,7 @@ export class DappsStakingEvents extends ServiceBase implements IDappsStakingEven
     }
 
     public async getAggregatedPeriodData(network: NetworkType, period: number): Promise<PeriodDataResponse[]> {
-        if (!['shibuya'].includes(network)) {
+        if (!['shibuya', 'shiden', 'astar'].includes(network)) {
             throw new Error(`This method is not supported for the network ${network}`);
         }
 


### PR DESCRIPTION
As title says...

Since indexer v7 has been deployed for all networks, period data fetching for Shiden and Astar can be enabled.