### PR TITLE
Circulation supply calculation fix

### DIFF
--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -70,7 +70,7 @@ export class StatsService implements IStatsService {
     private getTotalBalanceToExclude(balances: AccountData[]): BN {
         const sum = balances
             .map((balance) => {
-                return balance.free.add(balance.miscFrozen ?? balance.frozen);
+                return balance.free;
             })
             .reduce((partialSum, b) => partialSum.add(b), new BN(0));
 

--- a/tests/services/StatsService.test.ts
+++ b/tests/services/StatsService.test.ts
@@ -18,7 +18,7 @@ describe('getTokenStats', () => {
 
         const result = await service.getTokenStats('astar');
 
-        expect(result.circulatingSupply).toBe(83);
+        expect(result.circulatingSupply).toBe(85);
     });
 
     it('returns valid total supply', async () => {


### PR DESCRIPTION
Fix to properly calculate token circulation supply

<img width="349" alt="image" src="https://github.com/AstarNetwork/astar-token-api/assets/8452361/1128bb51-e21a-49c7-91cc-12fd806f24e8">
