### PR TITLE
Staker data aggregated by period

### DIFF
--- a/public/swagger.json
+++ b/public/swagger.json
@@ -1219,7 +1219,7 @@
         "tags": [
           "Dapps Staking"
         ],
-        "description": "Retrieves aggregated period data for the given staker.",
+        "description": "Retrieves aggregated period data for the given staker containing all stakes and rewards per period.",
         "parameters": [
           {
             "name": "network",
@@ -1253,7 +1253,7 @@
         "tags": [
           "Dapps Staking"
         ],
-        "description": "Retrieves aggregated period data for the given staker.",
+        "description": "Retrieves aggregated period data for the given staker containing sum of all rewards claimed and the current period stake.",
         "parameters": [
           {
             "name": "network",

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -1214,6 +1214,74 @@
         }
       }
     },
+    "/api/v3/{network}/dapps-staking/staker-aggregated/{address}": {
+      "get": {
+        "tags": [
+          "Dapps Staking"
+        ],
+        "description": "Retrieves aggregated period data for the given staker.",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya"
+            ]
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Staker address."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/{network}/dapps-staking/staker-aggregated-total/{address}": {
+      "get": {
+        "tags": [
+          "Dapps Staking"
+        ],
+        "description": "Retrieves aggregated period data for the given staker.",
+        "parameters": [
+          {
+            "name": "network",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The network name. Supported networks: astar",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya"
+            ]
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Staker address."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/v1/{network}/node/tx-perblock/total": {
       "get": {
         "tags": [

--- a/src/controllers/DappsStakingV3Controller.ts
+++ b/src/controllers/DappsStakingV3Controller.ts
@@ -442,7 +442,7 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
         app.route('/api/v3/:network/dapps-staking/staker-aggregated/:address').get(
             async (req: Request, res: Response) => {
                 /*
-                    #swagger.description = 'Retrieves aggregated period data for the given staker.'
+                    #swagger.description = 'Retrieves aggregated period data for the given staker containing all stakes and rewards per period.'
                     #swagger.tags = ['Dapps Staking']
                     #swagger.parameters['network'] = {
                         in: 'path',
@@ -472,7 +472,7 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
         app.route('/api/v3/:network/dapps-staking/staker-aggregated-total/:address').get(
             async (req: Request, res: Response) => {
                 /*
-                    #swagger.description = 'Retrieves aggregated period data for the given staker.'
+                    #swagger.description = 'Retrieves aggregated period data for the given staker containing sum of all rewards claimed and the current period stake.'
                     #swagger.tags = ['Dapps Staking']
                     #swagger.parameters['network'] = {
                         in: 'path',

--- a/src/controllers/DappsStakingV3Controller.ts
+++ b/src/controllers/DappsStakingV3Controller.ts
@@ -438,5 +438,65 @@ export class DappsStakingV3Controller extends ControllerBase implements IControl
                 }
             },
         );
+
+        app.route('/api/v3/:network/dapps-staking/staker-aggregated/:address').get(
+            async (req: Request, res: Response) => {
+                /*
+                    #swagger.description = 'Retrieves aggregated period data for the given staker.'
+                    #swagger.tags = ['Dapps Staking']
+                    #swagger.parameters['network'] = {
+                        in: 'path',
+                        description: 'The network name. Supported networks: astar',
+                        required: true,
+                        enum: ['astar', 'shiden', 'shibuya']
+                    }
+                    #swagger.parameters['address'] = {
+                        in: 'path',
+                        description: 'Staker address.',
+                        required: true,
+                    }
+                */
+                try {
+                    res.json(
+                        await this._dappsStakingEvents.getAggregatedStakerData(
+                            req.params.network as NetworkType,
+                            req.params.address,
+                        ),
+                    );
+                } catch (err) {
+                    this.handleError(res, err as Error);
+                }
+            },
+        );
+
+        app.route('/api/v3/:network/dapps-staking/staker-aggregated-total/:address').get(
+            async (req: Request, res: Response) => {
+                /*
+                    #swagger.description = 'Retrieves aggregated period data for the given staker.'
+                    #swagger.tags = ['Dapps Staking']
+                    #swagger.parameters['network'] = {
+                        in: 'path',
+                        description: 'The network name. Supported networks: astar',
+                        required: true,
+                        enum: ['astar', 'shiden', 'shibuya']
+                    }
+                    #swagger.parameters['address'] = {
+                        in: 'path',
+                        description: 'Staker address.',
+                        required: true,
+                    }
+                */
+                try {
+                    res.json(
+                        await this._dappsStakingEvents.getTotalAggregatedStakerData(
+                            req.params.network as NetworkType,
+                            req.params.address,
+                        ),
+                    );
+                } catch (err) {
+                    this.handleError(res, err as Error);
+                }
+            },
+        );
     }
 }

--- a/src/services/DappStaking/ResponseData.ts
+++ b/src/services/DappStaking/ResponseData.ts
@@ -45,3 +45,18 @@ export type PeriodDataResponse = {
     rewardAmount: bigint;
     stakeAmount: bigint;
 };
+
+export type StakerPeriodDataResponse = {
+    stakerAddress: string;
+    period: number;
+    stakerRewardAmount: bigint;
+    bonusRewardAmount: bigint;
+    stakeAmount: bigint;
+};
+
+export type StakerPeriodTotalResponse = {
+    stakerAddress: string;
+    totalBonusRewardsClaimed: bigint;
+    totalStakerRewardsClaimed: bigint;
+    currentStake: bigint;
+};

--- a/src/services/DappsStakingEvents.ts
+++ b/src/services/DappsStakingEvents.ts
@@ -12,6 +12,8 @@ import {
     DappStakingAggregatedData,
     DappStakingAggregatedResponse,
     PeriodDataResponse,
+    StakerPeriodDataResponse,
+    StakerPeriodTotalResponse,
 } from './DappStaking/ResponseData';
 import { IStatsIndexerService } from './StatsIndexerService';
 
@@ -37,6 +39,8 @@ export interface IDappsStakingEvents {
     getDappStakingRewardsAggregated(network: NetworkType, address: string, period: PeriodType): Promise<Pair[]>;
     getDappStakingStakersList(network: NetworkType, contractAddress: string): Promise<List[]>;
     getAggregatedPeriodData(network: NetworkType, period: number): Promise<PeriodDataResponse[]>;
+    getAggregatedStakerData(network: NetworkType, stakerAddress: string): Promise<StakerPeriodDataResponse[]>;
+    getTotalAggregatedStakerData(network: NetworkType, stakerAddress: string): Promise<StakerPeriodTotalResponse>;
 }
 
 export type RewardEventType = 'Reward' | 'BonusReward' | 'DAppReward';
@@ -564,6 +568,63 @@ export class DappsStakingEvents extends ServiceBase implements IDappsStakingEven
             console.error(e);
             return [];
         }
+    }
+
+    public async getAggregatedStakerData(
+        network: NetworkType,
+        stakerAddress: string,
+    ): Promise<StakerPeriodDataResponse[]> {
+        Guard.ThrowIfUndefined('network', network);
+        Guard.ThrowIfUndefined('stakerAddress', stakerAddress);
+        if (!['shibuya', 'shiden', 'astar'].includes(network)) {
+            throw new Error(`This method is not supported for the network ${network}`);
+        }
+
+        try {
+            const result = await axios.post(this.getApiUrl(network), {
+                query: `query {
+                  stakesPerStakerAndPeriods(where: {stakerAddress_eq: "${stakerAddress}"}) {
+                    stakerAddress
+                    period
+                    stakeAmount
+                    stakerRewardAmount
+                    bonusRewardAmount
+                  }
+                }`,
+            });
+
+            return result.data.data.stakesPerStakerAndPeriods;
+        } catch (e) {
+            console.error(e);
+            return [];
+        }
+    }
+
+    public async getTotalAggregatedStakerData(
+        network: NetworkType,
+        stakerAddress: string,
+    ): Promise<StakerPeriodTotalResponse> {
+        const data = await this.getAggregatedStakerData(network, stakerAddress);
+        let maxPeriod = -1;
+        const total = data.reduce(
+            (acc, item) => {
+                if (item.period > maxPeriod) {
+                    acc.currentStake = BigInt(item.stakeAmount);
+                    maxPeriod = item.period;
+                }
+                acc.totalStakerRewardsClaimed += BigInt(item.stakerRewardAmount);
+                acc.totalBonusRewardsClaimed += BigInt(item.bonusRewardAmount);
+                return acc;
+            },
+            {
+                currentStake: BigInt(0),
+                totalBonusRewardsClaimed: BigInt(0),
+                totalStakerRewardsClaimed: BigInt(0),
+                stakerAddress,
+            },
+        );
+
+        return total;
     }
 
     private getApiUrl(network: NetworkType): string {


### PR DESCRIPTION
Added two endpoints to fetch a staker data aggregated by period

- get data for all periods
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v3/astar/dapps-staking/staker-aggregated/<address>

- sumarize rewards for all period and return total stake for the last period (for Binance)
http://127.0.0.1:5001/astar-token-api/us-central1/app/api/v3/astar/dapps-staking/staker-aggregated-total/<address>

