### PR TITLE
Gradually remove base64 data from a dApp developer object

### DIFF
--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -79,6 +79,9 @@ export class FirebaseService implements IFirebaseService {
                 dapp.images = images.filter((x) => x !== null) as FileInfo[];
             }
 
+            // Check if developer images are stored as base64 and fix them.
+            await this.fixImages(dapp, collectionKey);
+
             dapp.description = this.decode(dapp.description);
             dapp.shortDescription = this.decode(dapp.shortDescription ?? '');
             return dapp;
@@ -102,6 +105,14 @@ export class FirebaseService implements IFirebaseService {
             if (image) {
                 const imageUrl = await this.uploadImage(image, collectionKey, dapp.address);
                 dapp.imagesUrl.push(imageUrl);
+            }
+        }
+
+        // upload developer images
+        for (const [index, dev] of dapp.developers.entries()) {
+            if (dev?.iconFile && dev.iconFile.startsWith('data:')) {
+                const imageInfo = this.createFileInfo(dev.iconFile, `developer-${index + 1}`);
+                dev.iconFile = await this.uploadImage(imageInfo, collectionKey, dapp.address);
             }
         }
 
@@ -160,12 +171,28 @@ export class FirebaseService implements IFirebaseService {
     }
 
     private async uploadImage(fileInfo: FileInfo, collectionKey: string, contractAddress: string): Promise<string> {
+        return await this.uploadEncodedImage(
+            fileInfo.base64content,
+            fileInfo.contentType,
+            fileInfo.name,
+            collectionKey,
+            contractAddress,
+        );
+    }
+
+    private async uploadEncodedImage(
+        base64content: string,
+        contentType: string,
+        fileName: string,
+        collectionKey: string,
+        contractAddress: string,
+    ): Promise<string> {
         const file = admin
             .storage()
             .bucket(functions.config().extfirebase.bucket)
-            .file(`${collectionKey}/${contractAddress}_${fileInfo.name}`);
-        const buffer = Buffer.from(this.decode(fileInfo.base64content), 'base64');
-        await file.save(buffer, { contentType: this.decode(fileInfo.contentType) });
+            .file(`${collectionKey}/${contractAddress}_${fileName}`);
+        const buffer = Buffer.from(this.decode(base64content), 'base64');
+        await file.save(buffer, { contentType: this.decode(contentType) });
         file.makePublic();
 
         return file.publicUrl();
@@ -222,6 +249,16 @@ export class FirebaseService implements IFirebaseService {
         }
     }
 
+    private createFileInfo(encodedContent: string, fileNameWithoutExtension: string): FileInfo {
+        const decoded = this.decode(encodedContent);
+        const parts = decoded.split(';base64,');
+        return {
+            name: `${fileNameWithoutExtension}.${parts[0].split('/')[1]}`,
+            contentType: parts[0].split(':')[1],
+            base64content: parts[1],
+        };
+    }
+
     /**
      * Firebase encodes '/' as &#x2F; before storing to the db, becasue '/' is special caracter,
      * so we need to fix this before sending to a client.
@@ -235,7 +272,7 @@ export class FirebaseService implements IFirebaseService {
         const data = await query.orderBy('name').get();
 
         const result: DappItem[] = [];
-        data.forEach((x) => {
+        for (const x of data.docs) {
             const data = x.data() as DappItem;
             data.creationTime = x.createTime.seconds;
             if (data.description) {
@@ -243,8 +280,31 @@ export class FirebaseService implements IFirebaseService {
             }
             data.shortDescription = this.decode(data.shortDescription ?? '');
             result.push(data);
-        });
+        }
 
         return result;
+    }
+
+    /**
+     * Fixes base64 images stored in JSON
+     * @param dapp to fix images for
+     * @param collectionKey collection key
+     * @returns value indicating if
+     */
+    private async fixImages(dapp: DappItem, collectionKey: string): Promise<boolean> {
+        let hasBase64 = false;
+        for (const [index, dev] of dapp.developers.entries()) {
+            if (dev.iconFile && dev.iconFile.startsWith('data:')) {
+                const imageInfo = this.createFileInfo(dev.iconFile, `developer-${index + 1}`);
+                dev.iconFile = dev.iconFile = await this.uploadImage(imageInfo, collectionKey, dapp.address);
+                hasBase64 = true;
+            }
+        }
+
+        if (hasBase64) {
+            await admin.firestore().collection(collectionKey).doc(dapp.address).set(dapp);
+        }
+
+        return hasBase64;
     }
 }

--- a/src/services/FirebaseService.ts
+++ b/src/services/FirebaseService.ts
@@ -80,7 +80,7 @@ export class FirebaseService implements IFirebaseService {
             }
 
             // Check if developer images are stored as base64 and fix them.
-            await this.fixImages(dapp, collectionKey);
+            await this.fixImages(dapp, collectionKey, true);
 
             dapp.description = this.decode(dapp.description);
             dapp.shortDescription = this.decode(dapp.shortDescription ?? '');
@@ -108,13 +108,8 @@ export class FirebaseService implements IFirebaseService {
             }
         }
 
-        // upload developer images
-        for (const [index, dev] of dapp.developers.entries()) {
-            if (dev?.iconFile && dev.iconFile.startsWith('data:')) {
-                const imageInfo = this.createFileInfo(dev.iconFile, `developer-${index + 1}`);
-                dev.iconFile = await this.uploadImage(imageInfo, collectionKey, dapp.address);
-            }
-        }
+        // Upload developer images if needed
+        await this.fixImages(dapp, collectionKey);
 
         //upload document
         const firebasePayload = {
@@ -289,19 +284,21 @@ export class FirebaseService implements IFirebaseService {
      * Fixes base64 images stored in JSON
      * @param dapp to fix images for
      * @param collectionKey collection key
-     * @returns value indicating if
+     * @returns value indicating if some images are fixed and the dApp was updated in Firebase.
      */
-    private async fixImages(dapp: DappItem, collectionKey: string): Promise<boolean> {
+    private async fixImages(dapp: DappItem, collectionKey: string, updateDappIfNeeded = false): Promise<boolean> {
         let hasBase64 = false;
-        for (const [index, dev] of dapp.developers.entries()) {
-            if (dev.iconFile && dev.iconFile.startsWith('data:')) {
-                const imageInfo = this.createFileInfo(dev.iconFile, `developer-${index + 1}`);
-                dev.iconFile = dev.iconFile = await this.uploadImage(imageInfo, collectionKey, dapp.address);
-                hasBase64 = true;
+        if (dapp?.developers) {
+            for (const [index, dev] of dapp.developers.entries()) {
+                if (dev?.iconFile && dev.iconFile.startsWith('data:')) {
+                    const imageInfo = this.createFileInfo(dev.iconFile, `developer-${index + 1}`);
+                    dev.iconFile = await this.uploadImage(imageInfo, collectionKey, dapp.address);
+                    hasBase64 = true;
+                }
             }
         }
 
-        if (hasBase64) {
+        if (hasBase64 && updateDappIfNeeded) {
             await admin.firestore().collection(collectionKey).doc(dapp.address).set(dapp);
         }
 


### PR DESCRIPTION
A long time ago I added a dApp developer images as base64 encoded data to JSON object. This hurts API (and the portal of course) performance so this PR contains changes to gradually upload base64 data as image to Firebase and to assign the uploaded image link to a dApp developer.

When I say gradually this means that all dApps won't be updated at once (I want to avoid the mayor catastrophe in case of bug). The above mentioned change will happen when
- a dApp owner updates owned dApp
- when a single dApp is fetched from API (user access a dApp details from the portal)