### PR TITLE
Engine update to Node v20

### DIFF
--- a/.github/workflows/pr_action.yml
+++ b/.github/workflows/pr_action.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [20.x]
         steps:
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [20.x]
         steps:
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [20.x]
         steps:
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "deploy": "firebase deploy"
     },
     "engines": {
-        "node": "18"
+        "node": "20"
     },
     "license": "MIT",
     "devDependencies": {

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -312,7 +312,13 @@
             "name": "network",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The network name. Supported networks: astar, shiden, shibuya",
+            "enum": [
+              "astar",
+              "shiden",
+              "shibuya"
+            ]
           }
         ],
         "responses": {

--- a/src/controllers/TokenStatsController.ts
+++ b/src/controllers/TokenStatsController.ts
@@ -274,7 +274,7 @@ export class TokenStatsController extends ControllerBase implements IControllerB
                 #swagger.tags = ['Token']
                 #swagger.parameters['network'] = {
                     in: 'path',
-                    description: 'The network name. Supported networks: astar, shiden, shibuya'
+                    description: 'The network name. Supported networks: astar, shiden, shibuya',
                     required: true,
                     enum: ['astar', 'shiden', 'shibuya']
                 }


### PR DESCRIPTION
It seems we need to switch to v20. Token API can't be deployed to Firebase anymore.

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/ecf5490d-ef44-48dc-b0ab-4e7bd89bfb4e" />
