### PR TITLE
Fix ASTR token maxSupply field to return `'N/A'` instead of total supply

### DIFF
--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -22,7 +22,7 @@ export type ExtendedTokenStats = {
     currencyCode: string;
     marketCap: number;
     circulatingSupply: number;
-    maxSupply: number;
+    maxSupply: 'N/A';
     provider: string;
     lastUpdatedTimestamp: number;
     accTradePrice24h: number | null;
@@ -125,7 +125,7 @@ export class StatsService extends DappStakingV3IndexerBase implements IStatsServ
                     marketCap: circulatingSupply * prices[index],
                     accTradePrice24h: null,
                     circulatingSupply,
-                    maxSupply: this.formatBalance(totalSupply, chainDecimals),
+                    maxSupply: 'N/A', // since ASTR is inflationary, we don't have a max supply
                     provider: 'Stake Technologies Pte Ltd',
                     lastUpdatedTimestamp,
                 };


### PR DESCRIPTION
The ASTR token is an inflationary token without a fixed maximum supply limit. Previously, the `maxSupply` field was returning the total supply value, which is misleading since ASTR doesn't have a maximum supply cap. Updated the `maxSupply` field to correctly reflect that ASTR has no maximum supply to return `'N/A'` instead of the total supply value